### PR TITLE
Add Snowflake mobile model v1 (Close #85)

### DIFF
--- a/.test/great_expectations/expectations/mobile/v1/mobile_base.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_base.json
@@ -138,7 +138,8 @@
   "meta": {
     "versions": {
       "test_suite_version": "1.0.1",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     },
     "great_expectations.__version__": "0.12.0"
   }

--- a/.test/great_expectations/expectations/mobile/v1/mobile_metadata.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_metadata.json
@@ -104,7 +104,8 @@
     "versions": {
       "test_suite_version": "1.0.1",
       "redshift_model_version": "1.0.0",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     },
     "great_expectations.__version__": "0.12.0"
   }

--- a/.test/great_expectations/expectations/mobile/v1/mobile_screen_view_in_session_values.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_screen_view_in_session_values.json
@@ -28,7 +28,8 @@
     "versions": {
       "test_suite_version": "1.0.1",
       "redshift_model_version": "1.0.0",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     },
     "great_expectations.__version__": "0.12.0"
   }

--- a/.test/great_expectations/expectations/mobile/v1/mobile_screen_views.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_screen_views.json
@@ -167,7 +167,8 @@
   "meta": {
     "versions": {
       "test_suite_version": "1.0.1",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     },
     "great_expectations.__version__": "0.12.0"
   }

--- a/.test/great_expectations/expectations/mobile/v1/mobile_sessions.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_sessions.json
@@ -1,3 +1,4 @@
+
 {
   "data_asset_type": "Dataset",
   "expectation_suite_name": "mobile_sessions",
@@ -154,7 +155,8 @@
   "meta": {
     "versions": {
       "test_suite_version": "1.0.1",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     },
     "great_expectations.__version__": "0.12.0"
   }

--- a/.test/great_expectations/expectations/mobile/v1/mobile_staging_reconciliation.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_staging_reconciliation.json
@@ -89,7 +89,8 @@
     "versions": {
       "test_suite_version": "1.0.1",
       "redshift_model_version": "1.0.0",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     }
   }
 }

--- a/.test/great_expectations/expectations/mobile/v1/mobile_users.json
+++ b/.test/great_expectations/expectations/mobile/v1/mobile_users.json
@@ -114,7 +114,8 @@
   "meta": {
     "versions": {
       "test_suite_version": "1.0.1",
-      "bigquery_model_version": "1.0.0"
+      "bigquery_model_version": "1.0.0",
+      "snowflake_model_version": "1.0.0"
     },
     "great_expectations.__version__": "0.12.0"
   }

--- a/.test/great_expectations/validation_configs/mobile/v1/snowflake/perm_tables.json
+++ b/.test/great_expectations/validation_configs/mobile/v1/snowflake/perm_tables.json
@@ -1,0 +1,50 @@
+{
+  "validation_operator_name": "action_list_operator",
+  "batches": [
+    {
+      "batch_kwargs": {
+        "schema": "derived",
+        "table": "mobile_screen_views",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_derived_mobile_sv"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_screen_views"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "query": "SELECT session_id, count(DISTINCT screen_views_in_session) AS dist_svis_values, count(*) - count(DISTINCT screen_view_in_session_index)  AS all_minus_dist_svisi, count(*) - count(DISTINCT screen_view_id) AS all_minus_dist_svids FROM derived.mobile_screen_views GROUP BY 1",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "ge_test_derived_mobile_sv_in_sess_values"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_screen_view_in_session_values"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "derived",
+        "table": "mobile_sessions",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_derived_mobile_sess"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_sessions"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "derived",
+        "table": "mobile_users",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_derived_mobile_usr"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_users"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "query": "SELECT *, rows_this_run - distinct_key_count AS diff_rows FROM derived.datamodel_metadata WHERE model = 'mobile'",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "ge_test_derived_mobile_metadata"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_metadata"]
+    }
+  ]
+}

--- a/.test/great_expectations/validation_configs/mobile/v1/snowflake/temp_tables.json
+++ b/.test/great_expectations/validation_configs/mobile/v1/snowflake/temp_tables.json
@@ -1,0 +1,68 @@
+{
+  "validation_operator_name": "action_list_operator",
+  "batches": [
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_events_this_run",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_events_this_run"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_base"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_events_staged",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_events_staged"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_base"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_screen_views_this_run",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_sv_this_run"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_screen_views"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_screen_views_staged",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_sv_staged"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_screen_views"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_sessions_this_run",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_sess_this_run"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_sessions"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_users_this_run",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_usr_this_run"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_users"]
+    },
+    {
+      "batch_kwargs": {
+        "schema": "scratch",
+        "table": "mobile_staging_reconciliation",
+        "datasource": "snowflake",
+        "snowflake_transient_table": "scratch.ge_test_scratch_mobile_staging_reconciliation"
+      },
+      "expectation_suite_names": ["mobile.v1.mobile_staging_reconciliation"]
+    }
+  ]
+}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Snowflake Mobile Version 1.0.0 (2021-05-06)
+---------------------------------------
+Add Snowflake mobile model v1 (Close #85)
+
 BigQuery Mobile Version 1.0.0 (2021-04-26)
 ---------------------------------------
 Update licence (Close #79)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you don't have a pipeline yet, you might be interested in finding out what Sn
 - [Mobile (v1)](mobile/v1)
   - [Redshift](mobile/v1/redshift)
   - [BigQuery](mobile/v1/bigquery)
-  - Snowflake (coming soon)
+  - [Snowflake](mobile/v1/snowflake)
 
 Documentation for the data models can be found on [our documentation site][docs-data-models].
 

--- a/mobile/v1/snowflake/CHANGELOG
+++ b/mobile/v1/snowflake/CHANGELOG
@@ -1,0 +1,3 @@
+Version 1.0.0 (2021-05-06)
+--------------------------
+Add Snowflake mobile model v1 (Close #85)

--- a/mobile/v1/snowflake/README.md
+++ b/mobile/v1/snowflake/README.md
@@ -1,0 +1,240 @@
+# Snowflake v1 mobile model README
+
+This readme contains a quickstart guide, and details of how the modules interact with each other. For a guide to configuring each module, there is a README in each of the modules' `playbooks` directory.
+
+To customise the model, we recommend following the guidance found in the README in the `sql/custom` directory.
+
+## Quickstart
+
+### Prerequisites
+
+[SQL-runner 0.9.3](https://github.com/snowplow/sql-runner) or later must be installed, and a dataset of mobile events from either the Snowplow [iOS tracker](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/objective-c-tracker/) or [Android tracker](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/android-tracker/) must be available in the database. The session context and screen view events most both be enabled for the mobile model to run. 
+
+### Configuration
+
+#### Authentication
+
+First, fill in the connection details for the target database in the relevant template in `.scripts/template/snowflake.yml.tmpl`.
+
+Set an environment variable, `SNOWFLAKE_PASSWORD`, to your Snowflake password. See the README in `.scripts` for more detail.
+
+#### Contexts
+
+The following contexts can be enabled depending on your tracker configuration:
+
+- Mobile context
+- Geolocation context
+- Application context
+- Screen context
+
+By default they are disabled. For more details on how to enable please see the [README](sql-runner/playbooks/standard/01-base/README.md) in the Base module's playbooks folder.
+
+#### Optional Modules
+
+Currently the app errors module for crash reporting is the only optional module. More will be added in the future as the tracker's functionality expands.
+
+Assuming your tracker is capturing `application_error` events, the module can be enabled within the app errors playbook. For more details on how to enable please see the [README](sql-runner/playbooks/standard/03-optional-modules/01-app-errors/README.md) in the app errors module's playbooks folder.
+
+#### Variables
+
+Variables in each module's playbook can also optionally be configured also. See each playbook directory's README for more detail on configuration of each module.
+
+### Run using the `run_config.sh` script
+
+To run the entire standard model, end to end:
+
+```bash
+bash .scripts/run_config.sh -b ~/pathTo/sql-runner -c mobile/v1/snowflake/sql-runner/configs/datamodeling.json -t .scripts/templates/snowflake.yml.tmpl;
+```
+
+See the README in the `.scripts/` directory for more details.
+
+## Custom Modules
+
+A guide to creating custom modules can be found in the README of the `sql/custom/` directory of the relevant model. Each custom module created must consist of a set of sql files and a playbook, or set of playbooks. The helper scripts described above can also be used to run custom modules.
+
+## Testing
+
+### Setup
+
+Python3 is required.
+
+Install Great Expectations and dependencies, and configure a datasource:
+
+```bash
+cd .test
+pip3 install -r requirements.txt
+great_expectations datasource new
+```
+
+Follow the CLI guide to configure access to your database. The configuration for your datasource will be generated in `.test/great_expectations/config/config_variables.tml` - these values can be replaced by environment variables if desired.
+
+Please be aware that the names of the tables to test have been hardcoded in the [validation configs](.test/great_expectations/validation_configs). If you are using a custom values for any of the `entropy`, `scratch_schema` or `output_schema` variables within your playbooks, you will need to manually ammend the validation configs accordingly.
+
+If you have enabled any optional modules within the main mobile model, you will need to enable tests on these modules too. For more details on how to enable please see the [README](sql-runner/playbooks/tests/00-staging-reconciliation/README.md) in the staging reconciliation module's playbooks folder.
+
+### Using the helper scripts
+
+To run the test suites alone:
+
+```bash
+bash .scripts/run_test.sh -d snowflake -c perm_tables -m mobile -a {credentials (optional)}
+bash .scripts/run_test.sh -d snowflake -c temp_tables -m mobile -a {credentials (optional)}
+```
+
+To run an entire run of the standard model, and tests end to end:
+
+```bash
+bash .scripts/e2e.sh -b {path_to_sql_runner} -d snowflake -m mobile -a {credentials (optional)}
+```
+
+To run a full battery of ten runs of the standard model, and tests:
+
+```bash
+bash .scripts/pr_check.sh -b {path_to_sql_runner} -d snowflake -m mobile -a {credentials (optional)}
+```
+
+### Adding to tests
+
+Check out the [Great Expectations documentation](https://docs.greatexpectations.io/en/latest/) for guidance on using it to run existing test suites directly, create new expectations, use the profiler, and autogenerate data documentation.
+
+Quickstart to create a new test suite:
+
+`great_expectations suite new`
+
+## Modules detail
+
+### 01-base
+
+Inputs:             atomic tables, `{{.output_schema}}.mobile_base_event_id_manifest`, `{{.output_schema}}.mobile_base_session_id_manifest`
+
+Persistent Outputs: `{{.scratch_schema}}.mobile_events_staged`,
+
+Temporary Outputs:  `{{.scratch_schema}}.mobile_events_this_run`, `{{.scratch_schema}}.mobile_base_duplicates_this_run`
+
+The base module executes the incremental logic of the model - it retrieves all events for sessions with new data, deduplicates, and adds any enabled contexts.
+
+The base module's 'complete' playbook (`99-base-complete.yml.tmpl`) updates the two relevant manifests, and cleans up temporary tables. The lifecycle of the `{{.scratch_schema}}.mobile_events_staged` table is completed by the `99-sessions-complete.yml.tmpl` step of the sessions module, when the table is truncated. This truncation can only occur during the completion step of the sessions module as `{{.scratch_schema}}.mobile_events_staged` is required as an input to the sessions module. This differs to the web model where the page views module's complete step would contain the truncation step.
+
+The `{{.scratch_schema}}.mobile_events_this_run` table contains all events relevant only to this run of the model (since the last time the `99-base-complete.yml.tmpl` playbook has run). This table is dropped and recomputed _every_ run of the module, regardless of whether another module has used the data.
+
+If there is a requirement that a custom module consumes data _more frequently than the screen views module for example_, the `{{.scratch_schema}}.mobile_events_this_run` table may be used for this purpose.
+
+The `{{.scratch_schema}}.mobile_events_staged` table is incrementally updated to contain all events relevant to any run of the base module _since the last time the sessions module consumed it_ (ie since the last time the `99-sessions-complete.yml.tmpl` has run). This allows one to run the base module more frequently than the subsequent modules (if, for example, a custom module reads from events_this_run). 
+
+Detail on configuring the base module's playbook can be found [in the relevant playbook directory's README](sql-runner/playbooks/standard/01-base).
+
+### 02-screen-views
+
+Inputs:             atomic tables, `{{.scratch_schema}}.mobile_events_staged`
+
+Persistent Outputs: `{{.output_schema}}.mobile_screen_views`, `{{.scratch_schema}}.mobile_screen_views_staged`
+
+Temporary Outputs:  `{{.scratch_schema}}.mobile_screen_views_this_run`
+
+The screen views module takes `{{.scratch_schema}}.mobile_events_staged` as its input, joins in and deduplicates screen_view_id, calculates the standard mobile screen views model, and updates the production mobile_screen_views table. It also produces the `{{.scratch_schema}}.mobile_screen_views_staged` and `{{.scratch_schema}}.mobile_screen_views_this_run` tables.
+
+The screen views module's 'complete' playbook `99-screen-views-complete.yml.tmpl` cleans up temporary tables. The lifecycle of the `{{.scratch_schema}}.mobile_screen_views_staged` table is completed by the `99-sessions-complete.yml.tmpl` step (of the subsequent module).
+
+The `{{.scratch_schema}}.mobile_screen_views_this_run` table contains all events relevant only to this run of the model (since the last time the `99-screen-views-complete.yml.tmpl` playbook has run). This table is dropped and recomputed _every_ run of the module, regardless of whether another module has used the data.
+
+If there is a requirement that a custom module consumes data _more frequently than the sessions module_, the `{{.scratch_schema}}.mobile_screen_views_this_run` table may be used for this purpose.
+
+The `{{.scratch_schema}}.mobile_screen_views_staged` table is incrementally updated to contain all events relevant to any run of the screen views module _since the last time the sessions module consumed it_ (ie since the last time the `99-sessions-complete.yml.tmpl` playbook has run). This allows one to run the screen views module more frequently than the sessions module (if, for example, a custom module reads from mobile_screen_views_this_run).
+
+Detail on configuring the screen views module's playbook can be found [in the relevant playbook directory's README](sql-runner/playbooks/02-screen-views).
+
+### 03-optional-modules
+
+#### 01-app-errors
+
+Inputs:             atomic tables, `{{.scratch_schema}}.mobile_events_staged`
+
+Persistent Outputs: `{{.output_schema}}.mobile_app_errors`, `{{.scratch_schema}}.mobile_app_errors_staged`
+
+Temporary Outputs:  `{{.scratch_schema}}.mobile_app_errors_this_run`
+
+The app errors module takes `{{.scratch_schema}}.mobile_events_staged` as its input, joins in the app errors context, calculates the app errors model, and updates the production mobile_app_errors table. It also produces the `{{.scratch_schema}}.mobile_app_errors_staged` and `{{.scratch_schema}}.mobile_app_errors_this_run` tables.
+
+This crash reporting module is disabled by default since it is not a requirement to run the mobile model. Despite this, the `{{.scratch_schema}}.mobile_app_errors_staged` table will be created irrespectively. This is to allow the sessions module to run correctly where the `{{.scratch_schema}}.mobile_app_errors_staged` table is required as an input.
+
+The app errors module's 'complete' playbook `99-app-errors-complete.yml.tmpl` cleans up temporary tables. The lifecycle of the `{{.scratch_schema}}.mobile_app_errors_staged` table is completed by the `99-sessions-complete.yml.tmpl` step (of the subsequent module).
+
+The `{{.scratch_schema}}.mobile_app_errors_this_run` table contains all events relevant only to this run of the model (since the last time the `99-app-errors-complete.yml.tmpl` playbook has run). This table is dropped and recomputed _every_ run of the module, regardless of whether another module has used the data.
+
+If there is a requirement that a custom module consumes data _more frequently than the sessions module_, the `{{.scratch_schema}}.mobile_app_errors_this_run` table may be used for this purpose.
+
+The `{{.scratch_schema}}.mobile_app_errors_staged` table is incrementally updated to contain all events relevant to any run of the screen views module _since the last time the sessions module consumed it_ (ie since the last time the `99-sessions-complete.yml.tmpl` playbook has run). This allows one to run the app errors module more frequently than the sessions module (if, for example, a custom module reads from mobile_app_errors_this_run).
+
+Detail on configuring the app errors module's playbook can be found [in the relevant playbook directory's README](sql-runner/playbooks/03-optional-modules/01-app-errors).
+
+### 04-sessions
+
+Inputs:             `{{.scratch_schema}}.mobile_screen_views_staged`, `{{.scratch_schema}}.mobile_app_errors_staged`, `{{.scratch_schema}}.mobile_events_staged`
+
+Persistent Outputs: `{{.output_schema}}.mobile_sessions`, `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged`
+
+Temporary Outputs:  `{{.scratch_schema}}.mobile_sessions_this_run`
+
+The sessions module takes the `_staged` output tables of the upstream modules as its input, calculates the standard sessions model, and updates the production sessions table. It also produces the `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged` and `{{.scratch_schema}}.mobile_sessions_this_run{{.entropy}}` tables.
+
+Unlike the other modules, the sessions module outputs a manifest of IDs as its staged table rather than a table containing all unprocessed data - this is due to the fact that the users step requires a longer lookback than the incremental structure contains, so there are obviously efficiency limitations.
+
+The sessions module's 'complete' playbook `99-sessions-complete.yml.tmpl` truncates the input tables, and cleans up temporary tables. The lifecycle of the `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged` table is completed by the `99-users-complete.yml.tmpl` step (of the subsequent module).
+
+The `{{.scratch_schema}}.mobile_sessions_this_run` table contains all events relevant only to this run of the model (since the last time the `99-sessions-complete.yml.tmpl` playbook has run). This table is dropped and recomputed _every_ run of the module, regardless of whether another module has used the data.
+
+If there is a requirement that a custom module consumes data _more frequently than the users module_, the `{{.scratch_schema}}.mobile_sessions_this_run` table may be used for this purpose.
+
+The `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged` table is incrementally updated to contain all IDs relevant to any run of the sessions module _since the last time the users module consumed it_ (ie since the last time the `99-users-complete.yml.tmpl` playbook has run). This allows one to run the sessions module more frequently than the users module (if, for example, a custom module reads from sessions_this_run and is more frequent than the page views module).
+
+Detail on configuring the sessions module's playbook can be found [in the relevant playbook directory's README](sql-runner/playbooks/04-sessions).
+
+### 05-users
+
+Inputs:             `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged`, `{{.output_schema}}.mobile_users_manifest`
+
+Persistent Outputs: `{{.output_schema}}.mobile_users`
+
+Temporary Outputs:  `{{.scratch_schema}}.mobile_users_this_run`
+
+The sessions module takes `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged` as its input, alongside the `{{.output_schema}}.mobile_users_manifest` table (which is self-maintained within the users module). It calculates the standard users model, and updates the production users table. It also produces the `{{.scratch_schema}}.mobile_users_this_run` table.
+
+Unlike the other modules, the users module doesn't take an input that contains all information required to run the module. It uses the `{{.output_schema}}.mobile_users_manifest` table to manage efficiency, and queries the sessions table to process data as far back in history as is required.
+
+The users module's 'complete' playbook `99-users-complete.yml.tmpl` truncates the `{{.scratch_schema}}.mobile_sessions_userid_manifest_staged` table, commits to the `{{.output_schema}}.mobile_users_manifest` and cleans up temporary tables. There is no `_staged` table for this module, as there are no subsequent modules.
+
+The `{{.scratch_schema}}.mobile_users_this_run` table contains all events relevant only to this run of the model (since the last time the `99-users-complete.yml.tmpl` playbook has run). This table is dropped and recomputed _every_ run of the module, regardless of whether another module has used the data.
+
+Detail on configuring the users module's playbook can be found [in the relevant playbook directory's README](sql-runner/playbooks/standard/05-users).
+
+## Scheduling
+
+### Asynchronous Runs
+
+While the model is configured by default to run the entire way through, i.e. from the base module through to the users module, it is possible to run each module independently. For instance one could run the screen views module hourly while only running the sessions module daily. To do so you should run hourly all modules up to and including the desired module i.e. the base and screen view modules. The sessions module can then be run on a daily schedule. A few points to note:
+
+- It is only when the sessions module is run that the `{{.scratch_schema}}.mobile_events_staged` is truncated. As a result, the hourly runs of the screen views module will both process new events data as well as re-process data stored in `mobile_events_staged` since the last time the sessions module ran. 
+- Prior to running sessions module ensure that all input modules have been run i.e. base, screen views and _any enabled optional modules_. This ensures all the inputs are up to date and in-sync.
+
+### Incomplete Runs
+
+It is not a requirement to run every module. For example you may decide you do not need sessions or users data and only want screen view data. To do so:
+
+- Set `stage_next` to `False` and `:ends_run:` to true in the screen views module. See the [README](sql-runner/playbooks/02-screen-views) for more details.
+- Run all modules up to and including the screen views module. 
+- Ensure that the sessions 'complete' playbook, `99-sessions-complete.yml.tmpl`, is the last step in the run. This playbook includes the truncation of the `mobile_events_staged` table. Without this truncation _each subsequent run will re-process data severely impacting performance._
+
+## A note on duplicates
+
+This version of the model (1.0.0) contains deduplication steps in both the base and screen views modules. The base module deduplicates on `event_id`, where _only_ the first row per `event_id` is kept (ordered by `collector_tstamp`).
+
+The screen view module deduplicates on `screen_view_id`, where _only_ the first row per `screen_view_id` is kept (ordered by `derived_tstamp`).
+
+## A note on Constraints and Clustering keys
+
+This 1.0.0 version of the Snowflake mobile model does not use Constraints or Clustering keys in the table definitions, even though it could.
+
+Concerning [clustering keys](https://docs.snowflake.com/en/user-guide/tables-clustering-keys.html#strategies-for-selecting-clustering-keys), Snowflake's naturally clusters the tables on insertion order, and there hasn't been evidence so far suggesting a change towards another manual clustering strategy.
+
+Concerning table [constraints](https://docs.snowflake.com/en/sql-reference/constraints-overview.html), it is a fact that Snowflake enforces **only** the `NOT NULL` constraint. Therefore, in this 1.0.0 version we decided to include only this constraint that is actually enforced, for clarity on the model's assumptions.

--- a/mobile/v1/snowflake/sql-runner/configs/datamodeling.json
+++ b/mobile/v1/snowflake/sql-runner/configs/datamodeling.json
@@ -1,0 +1,72 @@
+{
+  "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
+  "data": {
+    "enabled": true,
+    "storage": "Default",
+    "sqlRunner": "0.9.3",
+    "playbooks": [
+      {
+        "playbook": "standard/01-base/01-base-main",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/02-screen-views/01-screen-views-main",
+        "dependsOn": [
+          "standard/01-base/01-base-main"
+        ]
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/01-app-errors-main",
+        "dependsOn": [
+          "standard/01-base/01-base-main"
+        ]
+      },
+      {
+        "playbook": "standard/04-sessions/01-sessions-main",
+        "dependsOn": [
+          "standard/02-screen-views/01-screen-views-main",
+          "standard/03-optional-modules/01-app-errors/01-app-errors-main"
+        ]
+      },
+      {
+        "playbook": "standard/05-users/01-users-main",
+        "dependsOn": [
+          "standard/04-sessions/01-sessions-main"
+        ]
+      },
+      {
+        "playbook": "standard/01-base/99-base-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/02-screen-views/99-screen-views-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/99-app-errors-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/04-sessions/99-sessions-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/05-users/99-users-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      }
+    ],
+    "lockType": "hard",
+    "owners": [
+    ]
+  }
+}

--- a/mobile/v1/snowflake/sql-runner/configs/datamodeling_custom_module.json
+++ b/mobile/v1/snowflake/sql-runner/configs/datamodeling_custom_module.json
@@ -1,0 +1,85 @@
+{
+  "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
+  "data": {
+    "enabled": true,
+    "storage": "Default",
+    "sqlRunner": "0.9.3",
+    "playbooks": [
+      {
+        "playbook": "standard/01-base/01-base-main",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/02-screen-views/01-screen-views-main",
+        "dependsOn": [
+          "standard/01-base/01-base-main"
+        ]
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/01-app-errors-main",
+        "dependsOn": [
+          "standard/01-base/01-base-main"
+        ]
+      },
+      {
+        "playbook": "standard/04-sessions/01-sessions-main",
+        "dependsOn": [
+          "standard/02-screen-views/01-screen-views-main",
+          "standard/03-optional-modules/01-app-errors/01-app-errors-main"
+        ]
+      },
+      {
+        "playbook": "custom/04-session-goals/01-session-goals-main",
+        "dependsOn": [
+          "standard/04-sessions/01-sessions-main"
+        ]
+      },
+      {
+        "playbook": "standard/05-users/01-users-main",
+        "dependsOn": [
+          "standard/04-sessions/01-sessions-main"
+        ]
+      },
+      {
+        "playbook": "standard/01-base/99-base-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/02-screen-views/99-screen-views-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/99-app-errors-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "custom/04-session-goals/99-session-goals-complete",
+        "dependsOn": [
+          "custom/04-session-goals/01-session-goals-main"
+        ]
+      },
+      {
+        "playbook": "standard/04-sessions/99-sessions-complete",
+        "dependsOn": [
+          "custom/04-session-goals/01-session-goals-main",
+          "standard/05-users/01-users-main"
+        ]
+      },
+      {
+        "playbook": "standard/05-users/99-users-complete",
+        "dependsOn": [
+          "standard/05-users/01-users-main"
+        ]
+      }
+    ],
+    "lockType": "hard",
+    "owners": [
+    ]
+  }
+}

--- a/mobile/v1/snowflake/sql-runner/configs/post_test.json
+++ b/mobile/v1/snowflake/sql-runner/configs/post_test.json
@@ -1,0 +1,37 @@
+{
+  "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
+  "data": {
+    "enabled": true,
+    "storage": "Default",
+    "sqlRunner": "0.9.3",
+    "playbooks": [
+      {
+        "playbook": "standard/01-base/99-base-complete",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/02-screen-views/99-screen-views-complete",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/99-app-errors-complete",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/04-sessions/99-sessions-complete",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/05-users/99-users-complete",
+        "dependsOn": []
+      },
+      {
+        "playbook": "tests/00-staging-reconciliation/99-staging-reconciliation-complete",
+        "dependsOn": []
+      }
+    ],
+    "lockType": "hard",
+    "owners": [
+    ]
+  }
+}

--- a/mobile/v1/snowflake/sql-runner/configs/pre_test.json
+++ b/mobile/v1/snowflake/sql-runner/configs/pre_test.json
@@ -1,0 +1,48 @@
+{
+  "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
+  "data": {
+    "enabled": true,
+    "storage": "Default",
+    "sqlRunner": "0.9.3",
+    "playbooks": [
+      {
+        "playbook": "standard/01-base/01-base-main",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/02-screen-views/01-screen-views-main",
+        "dependsOn": [
+          "standard/01-base/01-base-main"
+        ]
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/01-app-errors-main",
+        "dependsOn": [
+          "standard/01-base/01-base-main"
+        ]
+      },
+      {
+        "playbook": "standard/04-sessions/01-sessions-main",
+        "dependsOn": [
+          "standard/02-screen-views/01-screen-views-main",
+          "standard/03-optional-modules/01-app-errors/01-app-errors-main"
+        ]
+      },
+      {
+        "playbook": "standard/05-users/01-users-main",
+        "dependsOn": [
+          "standard/04-sessions/01-sessions-main"
+        ]
+      },
+      {
+        "playbook": "tests/00-staging-reconciliation/01-staging-reconciliation-main",
+        "dependsOn": [
+          "standard/04-sessions/01-sessions-main"
+        ]
+      }
+    ],
+    "lockType": "hard",
+    "owners": [
+    ]
+  }
+}

--- a/mobile/v1/snowflake/sql-runner/configs/teardown_all.json
+++ b/mobile/v1/snowflake/sql-runner/configs/teardown_all.json
@@ -1,0 +1,33 @@
+{
+  "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
+  "data": {
+    "enabled": true,
+    "storage": "Default",
+    "sqlRunner": "0.9.3",
+    "playbooks": [
+      {
+        "playbook": "standard/01-base/XX-destroy-base",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/02-screen-views/XX-destroy-screen-views",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/03-optional-modules/01-app-errors/XX-destroy-app-errors",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/04-sessions/XX-destroy-sessions",
+        "dependsOn": []
+      },
+      {
+        "playbook": "standard/05-users/XX-destroy-users",
+        "dependsOn": []
+      }
+    ],
+    "lockType": "hard",
+    "owners": [
+    ]
+  }
+}

--- a/mobile/v1/snowflake/sql-runner/playbooks/custom/04-session-goals/01-session-goals-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/custom/04-session-goals/01-session-goals-main.yml.tmpl
@@ -1,0 +1,24 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:           snowflake/mobile/1.0.0
+  :scratch_schema:          scratch
+  :output_schema:           derived
+  :entropy:                 ""
+:steps:
+- :name: 01-session-goals-staged
+  :queries:
+    - :name: 01-session-goals-staged
+      :file: custom/04-session-goals/01-session-goals-staged.sql
+      :template: true
+- :name: 02-session-goals-upsert
+  :queries:
+    - :name: 02-session-goals-upsert
+      :file: custom/04-session-goals/02-session-goals-upsert.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/custom/04-session-goals/99-session-goals-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/custom/04-session-goals/99-session-goals-complete.yml.tmpl
@@ -1,0 +1,18 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:           snowflake/mobile/1.0.0
+  :scratch_schema:          scratch
+  :entropy:                 ""
+:steps:
+- :name: 99-session-goals-cleanup
+  :queries:
+    - :name: 99-session-goals-cleanup
+      :file: custom/04-session-goals/99-session-goals-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/custom/04-session-goals/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/custom/04-session-goals/README.md
@@ -1,0 +1,5 @@
+# Custom playbooks
+
+This directory contains playbooks for the example custom modules [the custom sql directory](../../sql/custom).
+
+The readme in that directory also contains a guide to adding custom modules.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/00-setup-metadata.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/00-setup-metadata.yml.tmpl
@@ -1,0 +1,20 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 00-setup-metadata
+  :queries:
+    - :name: 00-setup-metadata
+      :file: standard/00-setup/01-main/00-setup-metadata.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/99-metadata-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/99-metadata-complete.yml.tmpl
@@ -1,0 +1,20 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 99-metadata-cleanup
+  :queries:
+    - :name: 99-metadata-cleanup
+      :file: standard/00-setup/99-complete/99-metadata-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/README.md
@@ -1,0 +1,9 @@
+# Setup step playbooks
+
+These playbooks exist to accommodate scheduling jobs which don't conform to the usual flow of the standard model - they create and destroy the necessary tables to log metadata, with an ID which persists across modules.
+
+If running the standard model alone, or the standard model alongside custom steps, it is not necessary to run these steps. Instead, we can configure the `:ends_run:` variable to `true` in the `complete` playbook for the last module run in the standard model.
+
+In a scenario where we don't run the standard module, or we run portions of it on differing schedules, we can run the `00-setup-metadata.ymp.tmpl` playbook as the first step - to set up metadata and create the temporary run ID, and the `99-complete-metadata.yml.tmpl` playbook as the last step - to destroy the temporary run ID.
+
+If we would like to destroy the metadata tables for a full rebuild of the model, we may run the `XX-destroy-metadata.yml.tmpl` playbook to do so. It is advisable to rename the metadata table instead, however, in case there is some unforeseen need to see that data.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/XX-destroy-metadata.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/00-setup/XX-destroy-metadata.yml.tmpl
@@ -1,0 +1,25 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 99-metadata-cleanup
+  :queries:
+    - :name: 99-metadata-cleanup
+      :file: standard/00-setup/99-complete/99-metadata-cleanup.sql
+      :template: true
+- :name: XX-destroy-metadata
+  :queries:
+    - :name: XX-destroy-metadata
+      :file: standard/00-setup/XX-destroy/XX-destroy-metadata.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/01-base-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/01-base-main.yml.tmpl
@@ -1,0 +1,78 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:           snowflake/mobile/1.0.0
+  :model:                   mobile
+  :input_schema:            atomic
+  :scratch_schema:          scratch
+  :output_schema:           derived
+  :entropy:                 ""
+  :stage_next:              true
+  :start_date:              2020-01-01
+  :lookback_window_hours:
+  :days_late_allowed:
+  :update_cadence_days:     
+  :session_lookback_days:
+  :mobile_context:          false
+  :geolocation_context:     false
+  :application_context:     false
+  :screen_context:          false
+  :platform_filters:        []
+  :app_id_filters:          []
+:steps:
+- :name: 01-stored-procedures
+  :queries:
+    - :name: 01-stored-procedures
+      :file: standard/00-setup/01-main/01-stored-procedures.sql
+      :template: true
+- :name: 00-setup-base
+  :queries:
+    - :name: 00-setup-base
+      :file: standard/01-base/01-main/00-setup-base.sql
+      :template: true
+- :name: 01-new-events-limits
+  :queries:
+    - :name: 01-new-events-limits
+      :file: standard/01-base/01-main/01-new-events-limits.sql
+      :template: true
+- :name: 02-run-manifest
+  :queries:
+    - :name: 02-run-manifest
+      :file: standard/01-base/01-main/02-run-manifest.sql
+      :template: true
+- :name: 03-sessions-to-process
+  :queries:
+    - :name: 03-sessions-to-process
+      :file: standard/01-base/01-main/03-sessions-to-process.sql
+      :template: true
+- :name: 04-sessions-to-include
+  :queries:
+    - :name: 04-sessions-to-include
+      :file: standard/01-base/01-main/04-sessions-to-include.sql
+      :template: true
+- :name: 05-batch-limits
+  :queries:
+    - :name: 05-batch-limits
+      :file: standard/01-base/01-main/05-batch-limits.sql
+      :template: true
+- :name: 06-events-this-run
+  :queries:
+    - :name: 06-events-this-run
+      :file: standard/01-base/01-main/06-events-this-run.sql
+      :template: true
+- :name: 07-metadata
+  :queries:
+    - :name: 07-metadata
+      :file: standard/01-base/01-main/07-metadata.sql
+      :template: true
+- :name: 08-commit-base
+  :queries:
+    - :name: 08-commit-base
+      :file: standard/01-base/01-main/08-commit-base.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/99-base-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/99-base-complete.yml.tmpl
@@ -1,0 +1,27 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           false
+:steps:
+- :name: 98-base-manifest
+  :queries:
+    - :name: 98-base-manifest
+      :file: standard/01-base/99-complete/98-base-manifest.sql
+      :template: true
+- :name: 99-base-cleanup
+  :queries:
+    - :name: 99-base-cleanup
+      :file: standard/01-base/99-complete/99-base-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/README.md
@@ -1,0 +1,85 @@
+# Configuring the 01-base playbooks
+
+The Base module applies incremental logic to the atomic data, and produces deduplicated tables for subsequent modules to consume. This module is shared between the web and mobile models, with the `:model:` variable donating which model to run.
+
+`01-base-main.yml.tmpl` runs the main incremental logic. `99-base-complete.yml.tmpl` commits to the manifest, and runs cleanup steps afterwards. `XX-destroy-base.yml.tmpl` destroys all tables and manifests, for a complete rebuild.
+
+## Configuration quick reference
+
+### 01-base-main
+
+`:model:`       			 name of model to run, web or mobile.
+
+`:input_schema:`       name of atomic schema
+
+`:scratch_schema:`     name of scratch schema  
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `mobile_events_staged_test`). Must match entropy value used for all other modules in a given run. Populate with an empty string if no entropy value is needed.
+
+`:stage_next:`         update staging tables - set to true if running the next module. If true, make sure that the next module includes a 'complete' step.
+
+`:start_date:`         start date, used to seed manifest.
+
+`:lookback_window_hours:`    defaults to 6. Period of time (in hours) to look before the latest event in manifest - to account for late arriving data, which comes out of order.
+
+`:days_late_allowed:`  defaults to 3.  Period of time (in days) for which we should include late data. If the difference between collector tstamps for the session start and new event is greater than this value, data for that session will not be processed.
+
+`:update_cadence_days:`     defaults to 7. Period of time (in days) in the future (from the latest event in manifest) to look for new events.
+
+`:session_lookback_days:`   defaults to 365. Period of time (in days) to limit scan on session manifest. Exists to improve performance of model when we have a lot of sessions. Should be set to as large a number as practical.
+
+`:mobile_context:`      boolean - Mobile only. Configure whether to include data from the mobile context.
+
+`:geolocation_context:`    boolean - Mobile only. Configure whether to include data from the geolocation context.
+
+`:application_context:`    boolean - Mobile only. Configure whether to include data from the application context.
+
+`:screen_context:`    boolean - Mobile only. Configure whether to include data from the application context.
+
+`:platform_filters:`		array - Defaults to `web` and `mob` for the web and mobile models respectively. List of platforms to filter events by.
+
+`:app_id_filters:`		array - Optional. List of `app_id` to filter events by.
+
+**Notes:**
+
+`days_late_allowed` can be extended in order to account for incidents which cause very late data - for example downtime on the front end.
+
+`session_lookback_days` can cause incorrect data or duplicates if misconfigured - if events arrive with existing session_ids for sessions which pre-date the `session_lookback_days`, this will cause an issue. However this is very unlikely as the lookback should be far greater than what can be reasonably expected for this behaviour from non-bot activity.
+
+### 99-base-complete
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `web_events_staged_test`). Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       options: `debug` - only keeps main tables. `trace` - keeps all tables. `all` - cleans up everything.
+
+`:ends_run:`           set to true if there are no subsequent modules in the run, false otherwise.
+
+### XX-destroy-base
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `web_events_staged_test`). Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       should be set to `all` for a destroy.
+
+`:ends_run:`           should be set to true for a destroy.
+
+## Order of execution
+
+Custom steps should run before `99-base-complete.yml.tmpl`, but after `01-base-main.yml.tmpl`, as follows:
+
+1: 01-base-main.yml.tmpl
+
+2: AA-my-custom-base-level-module.yml.tmpl
+
+3: 99-base-complete.yml.tmpl
+
+Note that one should take care if adding custom logic at this stage, since everything downstream depends on it. For example, if duplicates are introduced here, every downstream join is liable to both suffer performance issues, and increase the number of duplicates exponentially.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/XX-destroy-base.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/01-base/XX-destroy-base.yml.tmpl
@@ -1,0 +1,27 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           true
+:steps:
+- :name: 99-base-cleanup
+  :queries:
+    - :name: 99-base-cleanup
+      :file: standard/01-base/99-complete/99-base-cleanup.sql
+      :template: true
+- :name: XX-destroy-base
+  :queries:
+    - :name: XX-destroy-base
+      :file: standard/01-base/XX-destroy/XX-destroy-base.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/01-screen-views-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/01-screen-views-main.yml.tmpl
@@ -1,0 +1,43 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:        snowflake/mobile/1.0.0
+  :model:                mobile
+  :scratch_schema:       scratch
+  :output_schema:        derived
+  :entropy:              ""
+  :stage_next:           true
+  :upsert_lookback_days:
+  :skip_derived:
+:steps:
+- :name: 01-stored-procedures
+  :queries:
+    - :name: 01-stored-procedures
+      :file: standard/00-setup/01-main/01-stored-procedures.sql
+      :template: true
+- :name: 00-setup-screen-views
+  :queries:
+    - :name: 00-setup-screen-views
+      :file: standard/02-screen-views/01-main/00-setup-screen-views.sql
+      :template: true
+- :name: 01-screen-views
+  :queries:
+    - :name: 01-screen-views
+      :file: standard/02-screen-views/01-main/01-screen-views.sql
+      :template: true
+- :name: 02-screen-views-metadata
+  :queries:
+    - :name: 02-screen-views-metadata
+      :file: standard/02-screen-views/01-main/02-screen-views-metadata.sql
+      :template: true
+- :name: 03-commit-screen-views
+  :queries:
+    - :name: 03-commit-screen-views
+      :file: standard/02-screen-views/01-main/03-commit-screen-views.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/99-screen-views-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/99-screen-views-complete.yml.tmpl
@@ -1,0 +1,21 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           false
+:steps:
+- :name: 99-screen-views-cleanup
+  :queries:
+    - :name: 99-screen-views-cleanup
+      :file: standard/02-screen-views/99-complete/99-screen-views-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/README.md
@@ -1,0 +1,61 @@
+# Configuring the 02-screen-views playbooks
+
+The screen views module runs the standard mobile screen views model. It takes the `mobile_events_staged` table - produced by the Base module - as an input.
+
+`01-screen-views-main.yml.tmpl` runs the main mobile model logic. `99-screen-views-complete.yml.tmpl` runs the cleanup steps afterwards. `XX-destroy-screen-views.yml.tmpl` destroys all tables and manifests, for a complete rebuild.
+
+## Configuration quick reference
+
+### 01-screen-views-main
+
+`:input_schema:`       name of atomic schema
+
+`:scratch_schema:`     name of scratch schema  
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `screen_views_test`). Must match entropy value used for all other modules in a given run.
+
+`:stage_next:`         update staging tables - set to true if running the next module. If true, make sure that the next module includes a 'complete' step.
+
+`:upsert_lookback_days:`    default 30. Period of time (in days) to look back over the production table in order to find rows to delete when upserting data. Where performance is not a concern, should be set to as long a value as possible.
+
+`:skip_derived:`       default false. Set to true to skip insert to production screen views table.
+
+**Note:** `upsert_lookback_days` can produce duplicates if set to too short a window.
+
+### 99-screen-views-complete
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       options: `debug` - only keeps main tables. `trace` - keeps all tables. `all` - cleans up everything.
+
+`:ends_run:`           set to true if there are no subsequent modules in the run, false otherwise.
+
+### XX-destroy-screen-views
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       should be set to "all" for a destroy.
+
+`:ends_run:`           should be set to true for a destroy.
+
+## Order of execution
+
+Custom steps should run before `99-screen-views-complete.yml.tmpl`, but after `01-screen-views-main.yml.tmpl`, as follows:
+
+1: 01-screen-views-main.yml.tmpl
+
+2: AA-my-custom-screen-views-level-module.yml.tmpl
+
+3: 99-screen-views-complete.yml.tmpl
+
+Custom modules should produce tables which join to the screen views table rather than altering it where possible.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/XX-destroy-screen-views.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/02-screen-views/XX-destroy-screen-views.yml.tmpl
@@ -1,0 +1,26 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           true
+:steps:
+- :name: 99-screen-views-cleanup
+  :queries:
+    - :name: 99-screen-views-cleanup
+      :file: standard/02-screen-views/99-complete/99-screen-views-cleanup.sql
+      :template: true
+- :name: XX-destroy-screen-views
+  :queries:
+    - :name: XX-destroy-screen-views
+      :file: standard/02-screen-views/XX-destroy/XX-destroy-screen-views.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/01-app-errors-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/01-app-errors-main.yml.tmpl
@@ -1,0 +1,44 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:        snowflake/mobile/1.0.0
+  :model:                mobile
+  :scratch_schema:       scratch
+  :output_schema:        derived
+  :entropy:              ""
+  :enabled:              false
+  :stage_next:           true
+  :upsert_lookback_days:
+  :skip_derived:
+:steps:
+- :name: 01-stored-procedures
+  :queries:
+    - :name: 01-stored-procedures
+      :file: standard/00-setup/01-main/01-stored-procedures.sql
+      :template: true
+- :name: 00-setup-app-errors
+  :queries:
+    - :name: 00-setup-app-errors
+      :file: standard/03-optional-modules/01-app-errors/01-main/00-setup-app-errors.sql
+      :template: true
+- :name: 01-app-errors
+  :queries:
+    - :name: 01-app-errors
+      :file: standard/03-optional-modules/01-app-errors/01-main/01-app-errors.sql
+      :template: true
+- :name: 02-app-errors-metadata
+  :queries:
+    - :name: 02-app-errors-metadata
+      :file: standard/03-optional-modules/01-app-errors/01-main/02-app-errors-metadata.sql
+      :template: true
+- :name: 03-commit-app-errors
+  :queries:
+    - :name: 03-commit-app-errors
+      :file: standard/03-optional-modules/01-app-errors/01-main/03-commit-app-errors.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/99-app-errors-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/99-app-errors-complete.yml.tmpl
@@ -1,0 +1,21 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           false
+:steps:
+- :name: 99-app-errors-cleanup
+  :queries:
+    - :name: 99-app-errors-cleanup
+      :file: standard/03-optional-modules/01-app-errors/99-complete/99-app-errors-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/README.md
@@ -1,0 +1,63 @@
+# Configuring the 01-app-errors playbooks
+
+The app errors module runs the mobile application errors model. It takes the `mobile_events_staged` table - produced by the Base module - as an input. The modules' staged output, `mobile_app_errors_staged`, is used as an input to the sessions module. The app errors module is optional, however if disabled an empty staged output table will still be created so as to allow the sessions module to run.
+
+`01-app-errors-main.yml.tmpl` runs the main mobile model logic. `99-app-errors-complete.yml.tmpl` runs the cleanup steps afterwards. `XX-destroy-app-errors.yml.tmpl` destroys all tables and manifests, for a complete rebuild.
+
+## Configuration quick reference
+
+### 01-app-errors-main
+
+`:input_schema:`       name of atomic schema
+
+`:scratch_schema:`     name of scratch schema  
+
+`:output_schema:`      name of derived schema
+
+`:enabled:`            boolean - Toggles the module on/off.  
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `mobile_app_errors_test`). Must match entropy value used for all other modules in a given run.
+
+`:stage_next:`         update staging tables - set to true if running the next module. If true, make sure that the next module includes a 'complete' step.
+
+`:upsert_lookback_days:`    default 30. Period of time (in days) to look back over the production table in order to find rows to delete when upserting data. Where performance is not a concern, should be set to as long a value as possible.
+
+`:skip_derived:`       default false. Set to true to skip insert to production app errors table.
+
+**Note:** `upsert_lookback_days` can produce duplicates if set to too short a window.
+
+### 99-app-errors-complete
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       options: `debug` - only keeps main tables. `trace` - keeps all tables. `all` - cleans up everything.
+
+`:ends_run:`           set to true if there are no subsequent modules in the run, false otherwise.
+
+### XX-destroy-app-errors
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       should be set to "all" for a destroy.
+
+`:ends_run:`           should be set to true for a destroy.
+
+## Order of execution
+
+Custom steps should run before `99-app-errors-complete.yml.tmpl`, but after `01-app-errors-main.yml.tmpl`, as follows:
+
+1: 01-app-errors-main.yml.tmpl
+
+2: AA-my-custom-app-errors-level-module.yml.tmpl
+
+3: 99-app-errors-complete.yml.tmpl
+
+Custom modules should produce tables which join to the app errors table rather than altering it where possible.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/XX-destroy-app-errors.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/03-optional-modules/01-app-errors/XX-destroy-app-errors.yml.tmpl
@@ -1,0 +1,26 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           true
+:steps:
+- :name: 99-app-errors-cleanup
+  :queries:
+    - :name: 99-app-errors-cleanup
+      :file: standard/03-optional-modules/01-app-errors/99-complete/99-app-errors-cleanup.sql
+      :template: true
+- :name: XX-destroy-app-errors
+  :queries:
+    - :name: XX-destroy-app-errors
+      :file: standard/03-optional-modules/01-app-errors/XX-destroy/XX-destroy-app-errors.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/01-sessions-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/01-sessions-main.yml.tmpl
@@ -1,0 +1,58 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:        snowflake/mobile/1.0.0
+  :model:                mobile
+  :scratch_schema:       scratch
+  :output_schema:        derived
+  :entropy:              ""
+  :stage_next:           true
+  :upsert_lookback_days:
+  :skip_derived:
+:steps:
+- :name: 01-stored-procedures
+  :queries:
+    - :name: 01-stored-procedures
+      :file: standard/00-setup/01-main/01-stored-procedures.sql
+      :template: true
+- :name: 00-setup-sessions
+  :queries:
+    - :name: 00-setup-sessions
+      :file: standard/04-sessions/01-main/00-setup-sessions.sql
+      :template: true
+- :name: 01-sessions-aggs
+  :queries:
+    - :name: 01-sessions-aggs
+      :file: standard/04-sessions/01-main/01-sessions-aggs.sql
+      :template: true
+- :name: 02-sessions-sv-details
+  :queries:
+    - :name: 02-sessions-sv-details
+      :file: standard/04-sessions/01-main/02-sessions-sv-details.sql
+      :template: true
+- :name: 03-sessions
+  :queries:
+    - :name: 03-sessions
+      :file: standard/04-sessions/01-main/03-sessions.sql
+      :template: true
+- :name: 04-sessions-metadata
+  :queries:
+    - :name: 04-sessions-metadata
+      :file: standard/04-sessions/01-main/04-sessions-metadata.sql
+      :template: true
+- :name: 05-sessions-prep-manifest
+  :queries:
+    - :name: 05-sessions-prep-manifest
+      :file: standard/04-sessions/01-main/05-sessions-prep-manifest.sql
+      :template: true
+- :name: 06-commit-sessions
+  :queries:
+    - :name: 06-commit-sessions
+      :file: standard/04-sessions/01-main/06-commit-sessions.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/99-sessions-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/99-sessions-complete.yml.tmpl
@@ -1,0 +1,26 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           false
+:steps:
+- :name: 98-truncate-upstream-staged
+  :queries:
+    - :name: 98-truncate-upstream-staged
+      :file: standard/04-sessions/99-complete/98-truncate-upstream-staged.sql
+      :template: true
+- :name: 99-sessions-cleanup
+  :queries:
+    - :name: 99-sessions-cleanup
+      :file: standard/04-sessions/99-complete/99-sessions-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/README.md
@@ -1,0 +1,59 @@
+# Configuring the 04-sessions playbooks
+
+The sessions module runs the standard mobile sessions model. It takes `mobile_events_staged`, `mobile_screen_views_staged` and `mobile_app_errors_staged` as inputs.
+
+`01-sessions-main.yml.tmpl` runs the main mobile model logic. `99-sessions-complete.yml.tmpl` truncates the input tables, and runs cleanup steps afterwards. `XX-destroy-sessions.yml.tmpl` destroys all tables and manifests, for a complete rebuild.
+
+## Configuration quick reference
+
+### 01-sessions-main
+
+`:scratch_schema:`     name of scratch schema  
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `mobile_sessions_test`). Must match entropy value used for all other modules in a given run.
+
+`:stage_next:`         update staging tables - set to true if running the next module. If true, make sure that the next module includes a 'complete' step.
+
+`:upsert_lookback_days:`    default 30. Period of time (in days) to look back over the production table in order to find rows to delete when upserting data. Where performance is not a concern, should be set to as long a value as possible.
+
+`:skip_derived:`       default false. Set to true to skip insert to production mobile sessions table.
+
+**Note:** `upsert_lookback_days` can produce duplicates if set to too short a window.
+
+### 99-sessions-complete
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       options: `debug` - only keeps main tables. `trace` - keeps all tables. `all` - cleans up everything.
+
+`:ends_run:`           set to true if there are no subsequent modules in the run, false otherwise.
+
+### XX-destroy-sessions
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       should be set to `all` for a destroy.
+
+`:ends_run:`           should be set to true for a destroy.
+
+## Order of execution
+
+Custom steps should run before `99-sessions-complete.yml.tmpl`, but after `01-sessions-main.yml.tmpl`, as follows:
+
+1: 01-sessions-main.yml.tmpl
+
+2: AA-my-custom-sessions-level-module.yml.tmpl
+
+3: 99-sessions-complete.yml.tmpl
+
+Custom modules should produce tables which join to the sessions table rather than altering it where possible.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/XX-destroy-sessions.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/04-sessions/XX-destroy-sessions.yml.tmpl
@@ -1,0 +1,26 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           true
+:steps:
+- :name: 99-sessions-cleanup
+  :queries:
+    - :name: 99-sessions-cleanup
+      :file: standard/04-sessions/99-complete/99-sessions-cleanup.sql
+      :template: true
+- :name: XX-destroy-sessions
+  :queries:
+    - :name: XX-destroy-sessions
+      :file: standard/04-sessions/XX-destroy/XX-destroy-sessions.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/01-users-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/01-users-main.yml.tmpl
@@ -1,0 +1,66 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :skip_derived:
+:steps:
+- :name: 01-stored-procedures
+  :queries:
+    - :name: 01-stored-procedures
+      :file: standard/00-setup/01-main/01-stored-procedures.sql
+      :template: true
+- :name: 00-setup-users
+  :queries:
+    - :name: 00-setup-users
+      :file: standard/05-users/01-main/00-setup-users.sql
+      :template: true
+- :name: 01-userids-this-run
+  :queries:
+    - :name: 01-userids-this-run
+      :file: standard/05-users/01-main/01-userids-this-run.sql
+      :template: true
+- :name: 02-users-limits
+  :queries:
+    - :name: 02-users-limits
+      :file: standard/05-users/01-main/02-users-limits.sql
+      :template: true
+- :name: 03-users-sessions-this-run
+  :queries:
+    - :name: 03-users-sessions-this-run
+      :file: standard/05-users/01-main/03-users-sessions-this-run.sql
+      :template: true
+- :name: 04-users-aggs
+  :queries:
+    - :name: 04-users-aggs
+      :file: standard/05-users/01-main/04-users-aggs.sql
+      :template: true
+- :name: 05-users-lasts
+  :queries:
+    - :name: 05-users-lasts
+      :file: standard/05-users/01-main/05-users-lasts.sql
+      :template: true
+- :name: 06-users
+  :queries:
+    - :name: 06-users
+      :file: standard/05-users/01-main/06-users.sql
+      :template: true
+- :name: 07-users-metadata
+  :queries:
+    - :name: 07-users-metadata
+      :file: standard/05-users/01-main/07-users-metadata.sql
+      :template: true
+- :name: 08-commit-users
+  :queries:
+    - :name: 08-commit-users
+      :file: standard/05-users/01-main/08-commit-users.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/99-users-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/99-users-complete.yml.tmpl
@@ -1,0 +1,26 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           true
+:steps:
+- :name: 98-manifest-and-truncate
+  :queries:
+    - :name: 98-manifest-and-truncate
+      :file: standard/05-users/99-complete/98-manifest-and-truncate.sql
+      :template: true
+- :name: 99-users-cleanup
+  :queries:
+    - :name: 99-users-cleanup
+      :file: standard/05-users/99-complete/99-users-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/README.md
@@ -1,0 +1,55 @@
+# Configuring the 05-users playbooks
+
+The users module runs the standard mobile sessions model - it takes the `mobile_sessions_userid_manifest_staged` table - produced by the Sessions module - as an input.
+
+`01-users-main.yml.tmpl` runs the main mobile model logic. `99-users-complete.yml.tmpl` truncates the input table, and runs cleanup steps afterwards. `XX-destroy-users.yml.tmpl` destroys all tables and manifests, for a complete rebuild.
+
+## Configuration quick reference
+
+### 01-users-main
+
+`:scratch_schema:`     name of scratch schema  
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `mobile_users_test`). Must match entropy value used for all other modules in a given run.
+
+`:skip_derived:`       default false. Set to true to skip insert to production users table.
+
+**Note:** `upsert_lookback_days` can produce duplicates if set to too short a window.
+
+### 99-users-complete
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       options: `debug` - only keeps main tables. `trace` - keeps all tables. `all` - cleans up everything.
+
+`:ends_run:`           set to true if there are no subsequent modules in the run, false otherwise.
+
+### XX-destroy-users
+
+`:scratch_schema:`     name of scratch schema
+
+`:output_schema:`      name of derived schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       should be set to `all` for a destroy.
+
+`:ends_run:`           should be set to true for a destroy.
+
+## Order of execution
+
+Custom steps should run before `99-users-complete.yml.tmpl`, but after `01-users-main.yml.tmpl`, as follows:
+
+1: 01-users-main.yml.tmpl
+
+2: AA-my-custom-users-level-module.yml.tmpl
+
+3: 99-users-complete.yml.tmpl
+
+Custom modules should produce tables which join to the users table rather than altering it where possible.

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/XX-destroy-users.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/05-users/XX-destroy-users.yml.tmpl
@@ -1,0 +1,26 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+  :cleanup_mode:       all
+  :ends_run:           true
+:steps:
+- :name: 99-users-cleanup
+  :queries:
+    - :name: 99-users-cleanup
+      :file: standard/05-users/99-complete/99-users-cleanup.sql
+      :template: true
+- :name: XX-destroy-users
+  :queries:
+    - :name: XX-destroy-users
+      :file: standard/05-users/XX-destroy/XX-destroy-users.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/tests/00-staging-reconciliation/01-staging-reconciliation-main.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/tests/00-staging-reconciliation/01-staging-reconciliation-main.yml.tmpl
@@ -1,0 +1,20 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :entropy:            ""
+  :app_errors:         false
+:steps:
+- :name: 00-staging-reconciliation
+  :queries:
+    - :name: 00-staging-reconciliation
+      :file: tests/00-staging-reconciliation/01-main/00-staging-reconciliation.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/tests/00-staging-reconciliation/99-staging-reconciliation-complete.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/tests/00-staging-reconciliation/99-staging-reconciliation-complete.yml.tmpl
@@ -1,0 +1,20 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :model_version:      snowflake/mobile/1.0.0
+  :model:              mobile
+  :scratch_schema:     scratch
+  :entropy:            ""
+  :cleanup_mode:       all
+:steps:
+- :name: 99-staging-reconciliation-cleanup
+  :queries:
+    - :name: 99-staging-reconciliation-cleanup
+      :file: tests/00-staging-reconciliation/99-complete/99-staging-reconciliation-cleanup.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/playbooks/tests/00-staging-reconciliation/README.md
+++ b/mobile/v1/snowflake/sql-runner/playbooks/tests/00-staging-reconciliation/README.md
@@ -1,0 +1,24 @@
+# Configuring the 00-staging-reconciliation playbooks
+
+The staging reconciliation module reconciles all the `_staging` output tables from the standard modules. It outputs to a scratch `mobile_staging_reconciliation` table which is then validated using Great Expectations. For all tests to pass, every columns in `mobile_staging_reconciliation` must equal 0.
+
+`01-staging-reconciliation-main.yml.tmpl` runs the main reconciliation logic. `99-staging-reconciliation-complete.yml.tmpl` drops the scratch table.
+
+## Configuration quick reference
+
+### 01-staging-reconciliation-main
+
+`:scratch_schema:`     name of scratch schema  
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables (eg. `_test` produces tables like `mobile_users_test`). Must match entropy value used for all other modules in a given run.
+
+`:app_errors:`         boolean - default false. Set to true if the App Errors module is enabled within the main mobile model. By enabling, the `_staged` output of the App Errors module is checked as part of the reconciliation.
+
+### 99-staging-reconciliation-complete
+
+`:scratch_schema:`     name of scratch schema
+
+`:entropy:`            string to append to all tables, to test without affecting prod tables. Must match entropy value used for all other modules in a given run.
+
+`:cleanup_mode:`       options: `debug` - only keeps main tables. `trace` - keeps all tables. `all` - cleans up everything.
+

--- a/mobile/v1/snowflake/sql-runner/sql/custom/04-session-goals/01-session-goals-staged.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/custom/04-session-goals/01-session-goals-staged.sql
@@ -1,0 +1,51 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+-- 1. Aggregate with a drop and recompute logic
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.session_goals_staged{{.entropy}} AS (
+
+  WITH goals AS (
+
+    SELECT
+      sv.session_id,
+      BOOLOR_AGG(sv.screen_view_name = 'registration') AS has_started_registration,
+      BOOLOR_AGG(sv.screen_view_name = 'my_account') AS has_completed_registration,
+      BOOLOR_AGG(sv.screen_view_name = 'search_results') AS has_used_search,
+      BOOLOR_AGG(sv.screen_view_name = 'products') AS has_viewed_products
+
+    FROM
+      {{.scratch_schema}}.mobile_screen_views_staged{{.entropy}} sv
+
+    GROUP BY 1
+
+  )
+
+  SELECT
+    s.session_id,
+    s.start_tstamp,
+    g.has_started_registration,
+    g.has_completed_registration,
+    g.has_used_search,
+    g.has_viewed_products,
+    IFF(g.has_started_registration AND g.has_completed_registration AND g.has_used_search AND g.has_viewed_products, TRUE, FALSE) AS has_completed_goals
+
+  FROM
+    {{.scratch_schema}}.mobile_sessions_this_run{{.entropy}} AS s --select from mobile_sessions_this_run to get start_tstamp. Screen view might not be start of session
+  INNER JOIN goals AS g
+    ON s.session_id = g.session_id
+
+);

--- a/mobile/v1/snowflake/sql-runner/sql/custom/04-session-goals/02-session-goals-upsert.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/custom/04-session-goals/02-session-goals-upsert.sql
@@ -1,0 +1,27 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+-- 2. Commit table procedure handles committing to prod, including table creation, and creation of new columns if 'automigrate' is set to TRUE
+
+CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',              -- source schema
+                                     'session_goals_staged{{.entropy}}', -- source table
+                                     '{{.output_schema}}',               -- target schema
+                                     'session_goals{{.entropy}}',        -- target table
+                                     'session_id',                       -- join key
+                                     'start_tstamp',                     -- partition key
+                                      TRUE);                             -- automigrate
+
+-- If we like, we can manually create and update our production table instead.

--- a/mobile/v1/snowflake/sql-runner/sql/custom/04-session-goals/99-session-goals-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/custom/04-session-goals/99-session-goals-cleanup.sql
@@ -1,0 +1,17 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+DROP TABLE IF EXISTS {{.scratch_schema}}.session_goals_staged{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/custom/README.md
+++ b/mobile/v1/snowflake/sql-runner/sql/custom/README.md
@@ -1,0 +1,115 @@
+# Adding custom sql
+
+This directory contains two examples of custom modules. The directories follow the same naming convention as the standard module, whereby each directory is assigned a number corresponding to the level of aggregation that the SQL is concerned with. In addition to these examples, below is a guide to creating custom modules.
+
+## Guidelines & Best Practice
+
+The v1 Model's modular structure allows for custom SQL modules to leverage the model's incrementalisation logic, and operate as 'plugins' to compliment the standard model. This can be achieved by using the `_staged` tables as an input, and producing custom tables which may join too the standard model's main production tables (for example, to aggregate custom contexts to a screen_view level), or provide a separate level of aggregation (for example a custom user interaction).
+
+The standard modules carry out the heavy lifting in establishing an incremental structure and providing the core logic for the most common mobile aggregation use cases. It also allows custom modules to be plugged in without impeding the maintainence of standard modules.
+
+The following best practices should be followed to ensure that updates and bugfixes to the model can be rolled out with minimal complication:
+
+- Custom modules should not modify the `_staged` tables
+- Custom modules should not modify the standard model's production tables (eg `mobile_screen_views`, `mobile_sessions` and `mobile_users`) - adding extra fields to the production tables can be achieved by producing a separate table which joins to the production table.
+- Custom modules should not modify any manifest tables.
+- Customisations should not modify the SQL in the standard model - they should only comprise of a new set of SQL statements, which produce a separate table.
+- The logic for custom SQL should be idempotent, and restart-safe - in other words, it should be written in such a way that a failure mid-way, or a re-run of the model will not change the deterministic output.
+
+In short, the standard modules can be treated as the source code for a distinct piece of software, and custom modules can be treated as self-maintained, additive plugins - in much the same way as a Java package may permit one to leverage public classes in their own API, and provide an entry point for custom programs to run, but will not permit one to modify the original API.
+
+The `_staged` and `_this_run` tables are considered part of the 'public' class of tables in this model structure, and so we can give assurances that non-breaking releases (ie. any v1.X release) won't alter them. The other tables may be used in custom SQL, but their logic and structure may change from release to release, or they may be removed. If one does use a scratch table in custom logic, any breaking changes can be mitigated by either amending the custom logic to suit, or copying the relevant steps from an old version of the model into the custom module. (However this will rarely be necessary).
+
+## Interacting with the model structure
+
+Each standard module produces a `_staged` table which serves as the input to the next module. This should also serve as the input to custom modules. For example, the `01-base` module produces the `scratch.mobile_events_staged` table - this is a subset of the pipeline's `events`, with the addition of various optional contexts, containing only data from sessions which contain new data in this run of the model. To aggregate atomic data, one can read from the `scratch.mobile_events_staged` table.
+
+Each standard module also contains a `99-{module}-complete` playbook, which completes the incremental logic for the previous step by truncating the input\*. This should run after both the custom and standard module have run. So, for our use case of aggregating atomic data, we would:
+
+  1. run the `01-base` module, to produce the `mobile_events_staged` table
+  2. run both the standard module and custom modules
+  3. Run the `99-sessions-complete` playbook (which truncates `events_staged`)
+
+For less common requirements, one can opt not to run a given standard module, or to wait until the end of the model before running all `99-{module}-complete` steps. For example, if the custom logic requires, the following order of operations is acceptable:
+
+  1. run `01-base`
+  2. run `02-screen-views`
+  3. run `02a-custom-sv-entity-aggregations`
+  4. run `03-sessions`
+  5. run `03a-custom-sessions-aggregations`
+  6. run `04a-custom-users-aggregations` (note no standard users module)
+  7. run `99-screen-views-complete`
+  8. run `99-sessions-complete`
+  9. run `99-users-complete`
+
+\* The exception to this is the screen views and optional modules. Their `99-{module}-complete` playbook does not truncate their input, `mobile_events_staged`. This is because the session module requires `mobile_events_staged` as an input and therefore the truncation occurs within the sessions module.
+
+## Producing custom tables
+
+### Design
+
+As mentioned above, custom modules should be written as additive-only, and should produce separate custom tables, as distinct from the tables produced by the standard module. If the requirement of the customisation is to add fields to compliment the production tables, this can be done in one of two ways: a) create a table which joins to the standard table on its joinkey, or b) create a custom table which duplicates the interesting fields from the standard model, to a new table which also contains the custom data.
+
+For example, at screen views level, one can either:
+
+a) Create a new table `mobile_screen_views_additions`, which is one-row-per screen_view_id, and contains the relevant data.
+
+or b) Create a new table `mobile_screen_views_custom`, which contains the relevant customisations joined to the relevant fields from `mobile_screen_views`.
+
+One should not amend `mobile_screen_views` directly.
+
+### Implementation
+
+The easiest way to integrate with the model's incremental structure is to implement a three-step process for custom tables:
+
+1. Write the relevant aggregation logic using drop and recompute logic, to produce a `_staged` table (only interacting with the input data)
+2. Use the provided `derived.commit_table()` procedure to commit to the production table.
+
+The standard model's incrementalisation logic ensures that all relevant data for a given row will be in the input, and only data for sessions which contain new data will be included. `commit_table` will do the job of creating the production table, or adding new columns as required. Note that `commit_table` requires a time key for partitions.
+
+Users who wish to specify exact constraints or additional features of the production table (eg. cluster keys) may create it first in SQL using a `CREATE TABLE statement`.
+
+An example of this can be seen in the `04-session-goals` directory, which makes use of the commit table procedure to update the production table.
+
+The arguments to the commit table procedure are as follows:
+
+```SQL     
+
+CALL derived.commit_table('scratch',              -- source schema
+                          'session_goals_staged', -- source table
+                          'derived',              -- target schema
+                          'session_goals',        -- target table
+                          'session_id',           -- join key
+                          'start_tstamp',         -- partition key
+                           TRUE);                 -- automigrate
+```
+
+If `automigrate` is TRUE, tables which don't exist will be created, and new columns will be added to the target table. If FALSE, the query will fail without committing unless the target table exists and columns match exactly.
+
+## Advanced usage - variable scheduling and non-standard requirements
+
+As mentioned above, the model's structure allows for some more complex use cases which may require a nuanced approach. Where this is required, it is advisable to begin by setting up the model in a standard way first, iterate upon it insofar as possible, and move to more complex requirements once the nuance is well understood.
+
+### Variable scheduling of modules with customisations
+
+The `_staging` tables update incrementally, and so it is possible to vary the schedule of different modules of the model without impact on the incremental structure. For example, one can run `01-base` and `02-screen-views` every hour, `04-sessions` once a day and `05-users` once a week.
+
+This is possible because every time `02-screen-views` runs, it incrementally updates the `mobile_screen_views_staged` to include all new data since the last run of the `04-sessions` module.
+
+Sometimes, one might require custom modules to run on a more frequent schedule than their standard counterparts. For example, one might wish to run a custom module to aggregate transaction events (from atomic data) every 30 mins, but only run the `02-screen-views` module once a day.
+
+This is possible using the above described structure - as long as the custom module is written to `DELETE` and `INSERT`, then it will remain accurate with every run. However, it is inefficient - every run of the custom module will process _all_ data since the last run of the `02-screen-views` module, including the data that's already been processed in the custom module.
+
+To allow for this kind of requirement, each module _also_ produces a `_this_run` table, which contains only the data for the _current_ run of the module. If one requires a custom module to run more frequently than a standard one - and aims for the most efficient means of doing so, one may use the `_this_run` table as an input.
+
+Do note that this requires that the custom module runs every time the previous module runs. So if using `_this_run` as an input, it is acceptable to run two jobs as follows:
+
+1. `01-base`, `02a-custom`
+2. `01-base`, `02a-custom`, `02-screen-views`
+
+But not as follows:
+
+1. `01-base`, `02a-custom`
+2. `01-base`, `02-screen-views`
+
+Since in the latter, running job 2 processes data which should be included in `02a-custom`, and that data is never persisted to the input of `02a-custom`.

--- a/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/01-main/00-setup-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/01-main/00-setup-metadata.sql
@@ -1,0 +1,46 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Permanent metadata table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}} (
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+-- A table storing an identifier for this run of a model - used to identify runs of the model across multiple modules/steps (eg. base, page views share this id per run)
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}} (
+  run_id TIMESTAMP_NTZ
+);
+
+TRUNCATE {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}};
+
+INSERT INTO {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}} (
+  SELECT
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/01-main/01-stored-procedures.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/01-main/01-stored-procedures.sql
@@ -1,0 +1,303 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+/*
+  UPDATE_MANIFEST
+  Updates manifest in either the base or users module.
+  Procedure required in order to rollback all DML statements if one fails within the transaction.
+  Inputs:
+  MODULE:   Name of the module containing the manifests to update.
+  To drop:
+  DROP PROCEDURE {{.output_schema}}.update_manifest(VARCHAR);
+*/
+CREATE OR REPLACE PROCEDURE {{.output_schema}}.update_manifest(MODULE VARCHAR)
+  RETURNS VARCHAR
+  LANGUAGE JAVASCRIPT
+  AS
+  $$
+
+  if (MODULE === 'base') {
+      var event_manifest_delete = `
+        DELETE FROM {{.output_schema}}.{{.model}}_base_event_id_manifest{{.entropy}}
+          WHERE
+            event_id IN (SELECT event_id FROM {{.scratch_schema}}.{{.model}}_events_this_run{{.entropy}})
+          AND
+            collector_tstamp >= (SELECT lower_limit FROM {{.scratch_schema}}.{{.model}}_base_run_limits{{.entropy}});`;
+
+      var event_manifest_insert = `
+        INSERT INTO {{.output_schema}}.{{.model}}_base_event_id_manifest{{.entropy}}
+          SELECT event_id, collector_tstamp FROM {{.scratch_schema}}.{{.model}}_events_this_run{{.entropy}};`;
+
+      var session_manifest_delete = `
+        DELETE FROM {{.output_schema}}.{{.model}}_base_session_id_manifest{{.entropy}}
+          WHERE
+            session_id IN (SELECT session_id FROM {{.scratch_schema}}.{{.model}}_base_sessions_to_include{{.entropy}});`;
+
+      var session_manifest_insert = `
+        INSERT INTO {{.output_schema}}.{{.model}}_base_session_id_manifest{{.entropy}}
+          SELECT * FROM {{.scratch_schema}}.{{.model}}_base_sessions_to_include{{.entropy}};`;
+
+      dmls = [event_manifest_delete, event_manifest_insert, session_manifest_delete, session_manifest_insert];
+  }
+  else if (MODULE === 'users') {
+      var users_manifest_delete = `
+        DELETE FROM {{.output_schema}}.mobile_users_manifest{{.entropy}}
+        WHERE device_user_id IN (SELECT device_user_id FROM {{.scratch_schema}}.mobile_users_userids_this_run{{.entropy}});`;
+
+      var users_manifest_insert = `
+        INSERT INTO {{.output_schema}}.mobile_users_manifest{{.entropy}}
+        SELECT * FROM {{.scratch_schema}}.mobile_users_userids_this_run{{.entropy}};`;
+
+      var users_manifest_truncate = `
+        TRUNCATE TABLE {{.scratch_schema}}.mobile_sessions_userid_manifest_staged{{.entropy}};`;
+
+      dmls = [users_manifest_delete, users_manifest_insert, users_manifest_truncate];
+  }
+  else {
+      return "No manifest updated. Pass either 'base' or 'users' to update the manifests within that module";
+  }
+
+  snowflake.createStatement({sqlText: `BEGIN;`}).execute();
+  try {
+
+      dmls.forEach(function(stmt) {
+          snowflake.createStatement({sqlText: stmt}).execute();
+      });
+      snowflake.createStatement({sqlText: `COMMIT;`}).execute();
+
+  } catch(ERROR) {
+      snowflake.createStatement({sqlText: `ROLLBACK;`}).execute();
+
+      throw Error("Transaction rolled back. Error:" + ERROR);
+  }
+
+  return "Success. Manifests in the " + MODULE + " have been updated";
+
+  $$
+;
+
+
+/*
+  COLUMN_CHECKER
+  Calculates how many columns in source table are present in the target table, and vice versa.
+  Inputs:
+  SOURCE_SCHEMA:         the schema of the source table
+  SOURCE_TABLE:          the source table
+  TARGET_SCHEMA:         the schema of the target table
+  TARGET_TABLE:          the target table
+  Output:
+  column_results:        array. [missing_in_source, missing_in_target, columns_to_add]
+  To drop:
+  DROP PROCEDURE {{.output_schema}}.column_checker(VARCHAR,VARCHAR,VARCHAR,VARCHAR);
+*/
+CREATE OR REPLACE PROCEDURE {{.output_schema}}.column_checker(SOURCE_SCHEMA VARCHAR,
+                                                              SOURCE_TABLE  VARCHAR,
+                                                              TARGET_SCHEMA VARCHAR,
+                                                              TARGET_TABLE  VARCHAR)
+  RETURNS ARRAY
+  LANGUAGE JAVASCRIPT
+  AS
+  $$
+
+  column_check_stmt = `
+  WITH target_columns AS (
+    SELECT
+      isc.column_name,
+      isc.data_type,
+      isc.ordinal_position
+
+    FROM information_schema.columns AS isc
+    WHERE table_schema = UPPER(:1)
+    AND table_name = UPPER(:2)
+    )
+
+  , source_columns AS (
+    SELECT
+      isc.column_name,
+      isc.data_type,
+      isc.ordinal_position,
+      isc.character_maximum_length,
+      isc.numeric_precision,
+      isc.numeric_scale
+
+    FROM information_schema.columns AS isc
+    WHERE table_schema = UPPER(:3)
+    AND table_name = UPPER(:4)
+    )
+
+  SELECT
+    SUM(CASE WHEN sc.column_name IS NULL THEN 1 ELSE 0 END) AS missing_in_source,
+    SUM(CASE WHEN tc.column_name IS NULL THEN 1 ELSE 0 END) AS missing_in_target,
+    LISTAGG(
+      CASE
+      WHEN tc.column_name IS NOT NULL
+        THEN NULL
+      WHEN sc.data_type='TEXT'
+        THEN CONCAT(sc.column_name, ' VARCHAR(',sc.character_maximum_length, ')')
+      WHEN sc.data_type='NUMBER'
+        THEN CONCAT(sc.column_name, ' NUMBER(', sc.numeric_precision, ',',sc.numeric_scale, ')')
+      ELSE
+        CONCAT(sc.column_name, ' ', sc.data_type) 
+      END
+      , ',') WITHIN GROUP (ORDER BY sc.ordinal_position) AS cols_to_add
+
+  FROM target_columns tc
+  FULL OUTER JOIN source_columns sc
+  ON tc.column_name = sc.column_name
+  AND tc.data_type = sc.data_type
+  AND tc.ordinal_position = sc.ordinal_position`;
+
+  var res = snowflake.createStatement({sqlText: column_check_stmt,
+                                       binds: [TARGET_SCHEMA, TARGET_TABLE, SOURCE_SCHEMA, SOURCE_TABLE]}
+                                      ).execute();
+  res.next();
+
+  missing_in_source = res.getColumnValue(1);
+  missing_in_target = res.getColumnValue(2);
+  columns_to_add = res.getColumnValue(3);
+
+  return [missing_in_source, missing_in_target, columns_to_add];
+
+  $$
+;
+
+
+/*
+  ALTER_TABLE
+  Adds the specified columns to the target table.
+  Inputs:
+  TARGET_SCHEMA:         the schema of the target table
+  TARGET_TABLE:          the target table to add columns to
+  COLUMNS_TO_ADD:        comma seperated list of colum definitions to add e.g. event_name VARCHAR(100)
+  To drop:
+  DROP PROCEDURE {{.output_schema}}.alter_table(VARCHAR,VARCHAR,VARCHAR);
+*/
+CREATE OR REPLACE PROCEDURE {{.output_schema}}.alter_table(TARGET_SCHEMA VARCHAR,
+                                                           TARGET_TABLE  VARCHAR,
+                                                           COLUMNS_TO_ADD VARCHAR)
+  RETURNS VARCHAR
+  LANGUAGE JAVASCRIPT
+  AS
+  $$
+
+  var target_namespace = TARGET_SCHEMA + `.` + TARGET_TABLE;
+
+  var alter_table_stmt = `ALTER TABLE identifier(:1) ADD COLUMN ` + COLUMNS_TO_ADD + `;`;
+
+  snowflake.createStatement({sqlText: alter_table_stmt,
+                             binds: [target_namespace]}).execute();
+
+  return "Success. Altered table: " + target_namespace + ". Added columns: " + COLUMNS_TO_ADD;
+
+  $$
+;
+
+
+/*
+  COMMIT_TABLE
+  Deletes and inserts data from the source table to the target.
+  If AUTOMIGRATE is enabled:
+    a) The target table will be created if it does not currently exist. 
+    b) If the target table already exists but does not contain all the columns in the source table, these columns will be added. 
+  Inputs:
+  SOURCE_SCHEMA:         the schema of the source table
+  SOURCE_TABLE:          the source table to select data from
+  TARGET_SCHEMA:         the schema of the target table
+  TARGET_TABLE:          the target table to delete/insert into
+  JOIN_KEY:              the join key between the source and target tables
+  PARTITION_KEY:         the partition of the target table
+  AUTOMIGRATE:           whether to automigrate staged table
+  To drop:
+  DROP PROCEDURE {{.output_schema}}.commit_table(VARCHAR,VARCHAR,VARCHAR,VARCHAR,VARCHAR,VARCHAR,BOOLEAN);
+*/
+CREATE OR REPLACE PROCEDURE {{.output_schema}}.commit_table(SOURCE_SCHEMA VARCHAR,
+                                                            SOURCE_TABLE  VARCHAR,
+                                                            TARGET_SCHEMA VARCHAR,
+                                                            TARGET_TABLE  VARCHAR,
+                                                            JOIN_KEY      VARCHAR,
+                                                            PARTITION_KEY VARCHAR,
+                                                            AUTOMIGRATE   BOOLEAN)
+  RETURNS VARCHAR
+  LANGUAGE JAVASCRIPT
+  AS
+  $$
+
+  SOURCE_NAMESPACE = SOURCE_SCHEMA + '.' + SOURCE_TABLE;
+  TARGET_NAMESPACE = TARGET_SCHEMA + '.' + TARGET_TABLE;
+
+  if (AUTOMIGRATE) {
+      /* Create table if doesnt already exists */
+      var create_target_table_query = `CREATE TABLE IF NOT EXISTS identifier(:1) AS (SELECT * FROM identifier(:2) WHERE FALSE);`;
+      snowflake.createStatement({sqlText: create_target_table_query,
+                                 binds: [TARGET_NAMESPACE, SOURCE_NAMESPACE]}).execute();
+  }
+
+  /* Check cols between staging and target and add if required */
+  var column_checker_procedure = `CALL {{.output_schema}}.column_checker(:1,:2,:3,:4);`;
+  
+  cols_checker_array = snowflake.createStatement({sqlText: column_checker_procedure,
+                                                  binds: [SOURCE_SCHEMA, SOURCE_TABLE, TARGET_SCHEMA, TARGET_TABLE]}
+                                                ).execute();
+  cols_checker_array.next();
+
+  [missing_in_source, missing_in_target, columns_to_add] = cols_checker_array.getColumnValue(1);
+
+  if (missing_in_source > 0) {
+      return "ERROR: Source table is missing column(s) which exist in target table."
+  }
+  else if (missing_in_target > 0 && !AUTOMIGRATE) {
+      return "ERROR: Target table is missing column(s), but automigrate is disabled."
+  }
+  else if (missing_in_target > 0 && AUTOMIGRATE) {
+      /* Alter table if AUTOMIGRATE enabled */
+      var alter_table_procedure = `CALL {{.output_schema}}.alter_table(:1,:2,:3);`;
+
+      snowflake.createStatement({sqlText: alter_table_procedure,
+                                 binds: [TARGET_SCHEMA, TARGET_TABLE, columns_to_add]}
+                                ).execute();
+  }
+
+  /* Prepare delete/insert statements */
+  var trg_delete_stmt = `DELETE FROM identifier(:1) 
+                         WHERE identifier(:2) IN (SELECT identifier(:2) FROM identifier(:3)) 
+                         AND identifier(:4) >= (SELECT TIMEADD(DAY, -{{or .upsert_lookback_days 30}}, MIN(identifier(:4))) FROM identifier(:3));`;
+
+  var tgr_insert_stmt = `INSERT INTO identifier(:1) SELECT * FROM identifier(:2);`;
+
+  /* Execute delete/insert */
+  snowflake.createStatement({sqlText: `BEGIN;`}).execute();
+  try {
+
+      snowflake.createStatement({sqlText: trg_delete_stmt,
+                                binds: [TARGET_NAMESPACE, JOIN_KEY, SOURCE_NAMESPACE, PARTITION_KEY]}
+                               ).execute();
+      snowflake.createStatement({sqlText: tgr_insert_stmt,
+                                binds: [TARGET_NAMESPACE, SOURCE_NAMESPACE]}
+                              ).execute();
+      snowflake.createStatement({sqlText: `COMMIT;`}).execute();
+
+  } catch(ERROR) {
+
+      snowflake.createStatement({sqlText: `ROLLBACK;`}).execute();
+      throw ERROR;
+
+  }
+
+  return "Success. Inserted data from: " + SOURCE_NAMESPACE + " to: " + TARGET_NAMESPACE;
+
+  $$
+;

--- a/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/99-complete/99-metadata-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/99-complete/99-metadata-cleanup.sql
@@ -1,0 +1,17 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/StoredProcedures.md
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/StoredProcedures.md
@@ -1,0 +1,34 @@
+# Stored procedures
+
+Below you can read about stored procedured defined for the Snowflake modules. They are defined under the `{{.output_schema}}` and you can find the source code [here](./01-main/01-stored-procedures.sql).
+
+For modularity, they are recreated in the first step of all `01-main` playbooks and they are explicitly dropped in the `XX-destroy` steps.
+
+Snowflake's [stored procedures](https://docs.snowflake.com/en/sql-reference/stored-procedures.html) are written in JavaScript and provide the ability to execute SQL through a JavaScript API. This makes it possible to leverage JavaScript and introduce complex procedural and error-handling logic or create SQL statements dynamically.
+
+## commit\_table
+
+This stored procedure is being used in the commit steps of the standard modules to create the `_staged` tables. It updates a target table with the data from the source table, overwritting any matching rows (based on the join key) in the target table and inserts non-matching rows. As such, it can also be useful to update any custom production tables one has created. An example of this can be seen in the custom module SQL directory. 
+
+
+**Arguments**
+ - source schema. The schema of the source table
+ - source table. The table to copy data from.
+ - target schema. The schema of the target table
+ - target table. The table to copy data into.
+ - join key. The key to join the source table to the target.
+ - partition key. The date partition key. This helps limit table scans during the delete/insert operation.
+ - automigrate flag. If true then a) an empty target table will be created based on the source table and b) if the target table already exists, any columns missing from the target table will be added.
+
+
+**Example call**
+
+```
+  CALL derived.commit_table('scratch',                      -- source schema
+                            'mobile_screen_views_this_run', -- source table
+                            'scratch',                      -- target schema
+                            'mobile_screen_views_staged',   -- target table
+                            'screen_view_id',               -- join key
+                            'derived_tstamp',               -- partition key
+                             FALSE);                        -- automigrate
+```

--- a/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/XX-destroy/XX-destroy-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/00-setup/XX-destroy/XX-destroy-metadata.sql
@@ -1,0 +1,17 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+DROP TABLE IF EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/00-setup-base.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/00-setup-base.sql
@@ -1,0 +1,102 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- A table storing an identifier for this run of a model - used to identify runs of the model across multiple modules/steps (eg. base, page views share this id per run)
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}} (
+  run_id TIMESTAMP_NTZ
+);
+
+-- When base runs, it's always the first module. So it's safe to just truncate here.
+TRUNCATE {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}};
+
+INSERT INTO {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}} (
+  SELECT
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ
+);
+
+-- Permanent metadata table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}} (
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+-- Setup temp metadata tables for this run
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_metadata_this_run{{.entropy}} (
+  id                         VARCHAR(64),
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+INSERT INTO {{.scratch_schema}}.{{.model}}_base_metadata_this_run{{.entropy}} (
+  SELECT
+    'run',
+    run_id,
+    '{{.model_version}}',
+    '{{.model}}',
+    'base',
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  FROM {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}}
+);
+
+
+-- Setup manifests
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.{{.model}}_base_event_id_manifest{{.entropy}}
+AS (
+  SELECT
+    'seed'::VARCHAR(36) AS event_id,
+    '{{.start_date}}'::TIMESTAMP_NTZ AS collector_tstamp
+);
+
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.{{.model}}_base_session_id_manifest{{.entropy}}
+AS (
+  SELECT
+    'seed'::VARCHAR(128) AS session_id,
+    '{{.start_date}}'::TIMESTAMP_NTZ AS min_tstamp
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/01-new-events-limits.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/01-new-events-limits.sql
@@ -1,0 +1,28 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Create a limit for this run - single row table.
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}}
+AS (
+  SELECT
+    TIMEADD(HOUR, -{{or .lookback_window_hours 6}}, MAX(collector_tstamp)) AS lower_limit,
+    TIMEADD(DAY, {{or .update_cadence_days 7}}, MAX(collector_tstamp)) AS upper_limit,
+    TIMEADD(DAY, -{{or .session_lookback_days 365}}, MAX(collector_tstamp)) AS session_limit
+
+  FROM
+    {{.output_schema}}.{{.model}}_base_event_id_manifest{{.entropy}}
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/02-run-manifest.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/02-run-manifest.sql
@@ -1,0 +1,42 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Subset the manifest for performance.
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_run_manifest{{.entropy}}
+AS (
+  SELECT
+    *
+
+  FROM
+    {{.output_schema}}.{{.model}}_base_event_id_manifest{{.entropy}}
+
+  WHERE
+    collector_tstamp >= (SELECT lower_limit FROM {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}})
+);
+
+-- subset session manifest table - should be as long a timeframe as practical
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_session_id_run_manifest{{.entropy}}
+AS (
+  SELECT
+    *
+
+  FROM
+    {{.output_schema}}.{{.model}}_base_session_id_manifest{{.entropy}}
+
+  WHERE
+    min_tstamp >= (SELECT session_limit FROM {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}})
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/03-sessions-to-process.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/03-sessions-to-process.sql
@@ -1,0 +1,48 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Get sessionids for new events
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_sessions_to_process{{.entropy}}
+AS (
+  SELECT
+    {{if eq .model "web"}} a.domain_sessionid {{else if eq .model "mobile"}} a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:sessionId::VARCHAR(36) {{end}} AS session_id,
+    MIN(a.collector_tstamp) AS min_tstamp,
+    MAX(a.collector_tstamp) AS max_tstamp
+
+  FROM {{.input_schema}}.events AS a
+
+  LEFT JOIN {{.scratch_schema}}.{{.model}}_base_run_manifest{{.entropy}} AS b
+    ON a.event_id = b.event_id
+
+  WHERE b.event_id IS NULL
+    AND a.collector_tstamp >= (SELECT lower_limit FROM {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}})
+    AND a.collector_tstamp <= (SELECT upper_limit FROM {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}})
+    AND {{if eq .model "web"}} a.domain_sessionid {{else if eq .model "mobile"}} a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:sessionId::VARCHAR(36) {{end}} IS NOT NULL
+    AND TIMESTAMPDIFF(DAY, a.dvce_created_tstamp, a.dvce_sent_tstamp) <= {{or .days_late_allowed 3}}
+    AND a.platform IN (
+      {{range $i, $platform := .platform_filters}} {{if $i}}, {{end}} '{{$platform}}'  -- User defined platforms if specified
+      {{else}}
+      {{if eq .model "web"}} 'web' {{else if eq .model "mobile"}} 'mob' {{end}} --default values
+      {{end}}
+      )
+    {{if .app_id_filters}}
+    -- Filter by app_id. Ignore if not specified.
+    AND a.app_id IN ( {{range $i, $app_id := .app_id_filters}} {{if $i}}, {{end}} '{{$app_id}}' {{end}} )
+    {{end}}
+
+  GROUP BY 1
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/04-sessions-to-include.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/04-sessions-to-include.sql
@@ -1,0 +1,32 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Get only those session ids that we'd like to process in this run.
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_sessions_to_include{{.entropy}}
+AS (
+  SELECT
+    a.session_id,
+    LEAST(a.min_tstamp, COALESCE(b.min_tstamp, a.min_tstamp)) AS min_tstamp
+
+  FROM {{.scratch_schema}}.{{.model}}_base_sessions_to_process{{.entropy}} AS a
+
+  LEFT JOIN {{.scratch_schema}}.{{.model}}_base_session_id_run_manifest{{.entropy}} AS b
+    ON a.session_id = b.session_id
+
+  WHERE
+    TIMESTAMPDIFF(DAY, COALESCE(b.min_tstamp, a.max_tstamp), a.max_tstamp) <= {{or .days_late_allowed 3}}
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/05-batch-limits.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/05-batch-limits.sql
@@ -1,0 +1,27 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Create a new limit based on this data
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_run_limits{{.entropy}}
+AS (
+  SELECT
+    MIN(min_tstamp) AS lower_limit,
+    (SELECT upper_limit FROM {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}}) AS upper_limit
+
+  FROM
+    {{.scratch_schema}}.{{.model}}_base_sessions_to_include{{.entropy}}
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/06-events-this-run.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/06-events-this-run.sql
@@ -1,0 +1,151 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+-- Not excluding contexts_com_snowplowanalytics_snowplow_web_page_1, unlike SF web model. 
+-- When we share this new base logic between the mobile and web models, this extra column will be a breaking change.
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_events_this_run{{.entropy}}
+AS (
+
+  WITH events AS (
+    SELECT
+      {{if eq .model "web"}} a.contexts_com_snowplowanalytics_snowplow_web_page_1[0]:id::VARCHAR(36) AS page_view_id, {{end}}
+      {{if eq .model "mobile"}}
+        -- screen view events
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:id::VARCHAR(36) AS screen_view_id,
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:name::VARCHAR AS screen_view_name,
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:previousId::VARCHAR(36) AS screen_view_previous_id,
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:previousName::VARCHAR AS screen_view_previous_name,
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:previousType::VARCHAR AS screen_view_previous_type,
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:transitionType::VARCHAR AS screen_view_transition_type,
+        a.unstruct_event_com_snowplowanalytics_mobile_screen_view_1:type::VARCHAR AS screen_view_type,
+        -- session context
+        a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:sessionId::VARCHAR(36) AS session_id,
+        a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:sessionIndex::INT AS session_index,
+        a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:previousSessionId::VARCHAR(36) AS previous_session_id,
+        a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:userId::VARCHAR(36) AS device_user_id,
+        a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:firstEventId::VARCHAR(36) AS session_first_event_id,
+        -- mobile context
+        {{if eq .mobile_context true}}
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:deviceManufacturer::VARCHAR AS device_manufacturer,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:deviceModel::VARCHAR AS device_model,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:osType::VARCHAR AS os_type,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:osVersion::VARCHAR AS os_version,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:androidIdfa::VARCHAR AS android_idfa,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:appleIdfa::VARCHAR AS apple_idfa,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:appleIdfv::VARCHAR AS apple_idfv,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:carrier::VARCHAR AS carrier,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:openIdfa::VARCHAR AS open_idfa,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:networkTechnology::VARCHAR AS network_technology,
+          a.contexts_com_snowplowanalytics_snowplow_mobile_context_1[0]:networkType::VARCHAR(255) AS network_type,
+        {{else}}
+          CAST(NULL AS VARCHAR) AS device_manufacturer,
+          CAST(NULL AS VARCHAR) AS device_model,
+          CAST(NULL AS VARCHAR) AS os_type,
+          CAST(NULL AS VARCHAR) AS os_version,
+          CAST(NULL AS VARCHAR) AS android_idfa,
+          CAST(NULL AS VARCHAR) AS apple_idfa,
+          CAST(NULL AS VARCHAR) AS apple_idfv,
+          CAST(NULL AS VARCHAR) AS carrier,
+          CAST(NULL AS VARCHAR) AS open_idfa,
+          CAST(NULL AS VARCHAR) AS network_technology,
+          CAST(NULL AS VARCHAR(255)) AS network_type,
+        {{end}}
+        -- geo context
+        {{if eq .geolocation_context true}}
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:latitude::FLOAT AS device_latitude,
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:longitude::FLOAT AS device_longitude,
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:latitudeLongitudeAccuracy::FLOAT AS device_latitude_longitude_accuracy,
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:altitude::FLOAT AS device_altitude,
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:altitudeAccuracy::FLOAT AS device_altitude_accuracy,
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:bearing::FLOAT AS device_bearing,
+          a.contexts_com_snowplowanalytics_snowplow_geolocation_context_1[0]:speed::FLOAT AS device_speed,
+        {{else}}
+          CAST(NULL AS FLOAT) AS device_latitude,
+          CAST(NULL AS FLOAT) AS device_longitude,
+          CAST(NULL AS FLOAT) AS device_latitude_longitude_accuracy,
+          CAST(NULL AS FLOAT) AS device_altitude,
+          CAST(NULL AS FLOAT) AS device_altitude_accuracy,
+          CAST(NULL AS FLOAT) AS device_bearing,
+          CAST(NULL AS FLOAT) AS device_speed,
+        {{end}}
+        -- app context
+        {{if eq .application_context true}}
+          a.contexts_com_snowplowanalytics_mobile_application_1[0]:build::VARCHAR(255) AS build,
+          a.contexts_com_snowplowanalytics_mobile_application_1[0]:version::VARCHAR(255) AS version,
+        {{else}}
+          CAST(NULL AS VARCHAR(255)) AS build,
+          CAST(NULL AS VARCHAR(255)) AS version,
+        {{end}}
+        -- screen context
+        {{if eq .screen_context true}}
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:id::VARCHAR(36) AS screen_id,
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:name::VARCHAR AS screen_name,
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:activity::VARCHAR AS screen_activity,
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:fragment::VARCHAR AS screen_fragment,
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:topViewController::VARCHAR AS screen_top_view_controller,
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:type::VARCHAR AS screen_type,
+          a.contexts_com_snowplowanalytics_mobile_screen_1[0]:viewController::VARCHAR AS screen_view_controller,
+        {{else}}
+          CAST(NULL AS VARCHAR(36)) AS screen_id,
+          CAST(NULL AS VARCHAR) AS screen_name,
+          CAST(NULL AS VARCHAR) AS screen_activity,
+          CAST(NULL AS VARCHAR) AS screen_fragment,
+          CAST(NULL AS VARCHAR) AS screen_top_view_controller,
+          CAST(NULL AS VARCHAR) AS screen_type,
+          CAST(NULL AS VARCHAR) AS screen_view_controller,
+        {{end}}
+      {{end}}
+      a.*
+
+    FROM 
+      {{.input_schema}}.events AS a
+    INNER JOIN 
+      {{.scratch_schema}}.{{.model}}_base_sessions_to_include{{.entropy}} AS b
+      ON {{if eq .model "web"}} a.domain_sessionid {{else if eq .model "mobile"}} a.contexts_com_snowplowanalytics_snowplow_client_session_1[0]:sessionId::VARCHAR(36) {{end}} = b.session_id
+
+    WHERE 
+      a.collector_tstamp >= (SELECT lower_limit FROM {{.scratch_schema}}.{{.model}}_base_run_limits{{.entropy}})
+      AND a.collector_tstamp <= (SELECT upper_limit FROM {{.scratch_schema}}.{{.model}}_base_run_limits{{.entropy}})
+      AND a.platform IN (
+          {{range $i, $platform := .platform_filters}} {{if $i}}, {{end}} '{{$platform}}'  -- User defined platforms if specified
+          {{else}}
+          {{if eq .model "web"}} 'web' {{else if eq .model "mobile"}} 'mob' {{end}} --default values
+          {{end}}
+          )
+    {{if .app_id_filters}}
+        -- Filter by app_id. Ignore if not specified.
+      AND a.app_id IN ( {{range $i, $app_id := .app_id_filters}} {{if $i}}, {{end}} '{{$app_id}}' {{end}} )
+    {{end}}
+  )
+  
+  , deduped_events AS (
+  SELECT
+    e.*
+
+  FROM events e
+
+  QUALIFY
+    ROW_NUMBER() OVER (PARTITION BY e.event_id ORDER BY e.collector_tstamp) = 1
+  )
+
+  SELECT
+    d.*
+    {{if eq .model "mobile"}} , ROW_NUMBER() OVER(PARTITION BY d.session_id ORDER BY d.derived_tstamp) AS event_index_in_session {{end}}
+
+  FROM
+    deduped_events d
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/07-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/07-metadata.sql
@@ -1,0 +1,47 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.{{.model}}_base_run_metadata_temp{{.entropy}}
+AS (
+  SELECT
+    'run' AS id,
+    COUNT(*) AS rows_this_run,
+    'event_id' AS distinct_key,
+    COUNT(DISTINCT event_id) AS distinct_key_count,
+    'collector_tstamp' AS time_key,
+    MIN(collector_tstamp) AS min_time_key,
+    MAX(collector_tstamp) AS max_time_key
+
+  FROM
+    {{.scratch_schema}}.{{.model}}_events_this_run{{.entropy}}
+);
+
+UPDATE {{.scratch_schema}}.{{.model}}_base_metadata_this_run{{.entropy}}
+  SET
+    run_end_tstamp = CURRENT_TIMESTAMP::TIMESTAMP_NTZ,  -- tbc x2
+    rows_this_run = b.rows_this_run,
+    distinct_key = b.distinct_key,
+    distinct_key_count = b.distinct_key_count,
+    time_key = b.time_key,
+    min_time_key = b.min_time_key,
+    max_time_key = b.max_time_key
+
+  FROM
+    {{.scratch_schema}}.{{.model}}_base_run_metadata_temp{{.entropy}} AS b
+
+  WHERE
+    {{.scratch_schema}}.{{.model}}_base_metadata_this_run{{.entropy}}.id = b.id;

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/08-commit-base.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/01-main/08-commit-base.sql
@@ -1,0 +1,49 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- staged tables
+{{if eq .stage_next true}}
+
+  CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',                    -- source schema
+                                       '{{.model}}_events_this_run{{.entropy}}', -- source table
+                                       '{{.scratch_schema}}',                    -- target schema
+                                       '{{.model}}_events_staged{{.entropy}}',   -- target table
+                                       'event_id',                               -- join key
+                                       'collector_tstamp',                       -- partition key
+                                        TRUE);                                   -- automigrate
+
+{{end}}
+
+-- commit metadata
+INSERT INTO {{.output_schema}}.datamodel_metadata{{.entropy}}
+  SELECT
+    run_id,
+    model_version,
+    model,
+    module,
+    run_start_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS run_end_tstamp,
+    rows_this_run,
+    distinct_key,
+    distinct_key_count,
+    time_key,
+    min_time_key,
+    max_time_key,
+    duplicate_rows_removed,
+    distinct_keys_removed
+  FROM
+    {{.scratch_schema}}.{{.model}}_base_metadata_this_run{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/99-complete/98-base-manifest.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/99-complete/98-base-manifest.sql
@@ -1,0 +1,18 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CALL {{.output_schema}}.update_manifest('base');

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/99-complete/99-base-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/99-complete/99-base-cleanup.sql
@@ -1,0 +1,42 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+{{if eq .cleanup_mode "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_new_events_limits{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_sessions_to_process{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_sessions_to_include{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_metadata_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_run_metadata_temp{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_session_id_run_manifest{{.entropy}};
+
+{{end}}
+
+{{if eq .cleanup_mode "debug" "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_run_manifest{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_events_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_base_run_limits{{.entropy}};
+  DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+{{end}}
+
+{{if eq .ends_run true}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_metadata_run_id{{.entropy}};
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/01-base/XX-destroy/XX-destroy-base.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/01-base/XX-destroy/XX-destroy-base.sql
@@ -1,0 +1,41 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+DROP TABLE IF EXISTS {{.output_schema}}.{{.model}}_base_event_id_manifest{{.entropy}};
+DROP TABLE IF EXISTS {{.output_schema}}.{{.model}}_base_session_id_manifest{{.entropy}};
+DROP TABLE IF EXISTS {{.scratch_schema}}.{{.model}}_events_staged{{.entropy}};
+
+-- Snowflake supports overloading of procedure names.
+-- So the data types of the arguments are needed to identify the procedure to drop.
+DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.column_checker(VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.alter_table(VARCHAR,
+                                                        VARCHAR,
+                                                        VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.commit_table(VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         BOOLEAN);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/00-setup-screen-views.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/00-setup-screen-views.sql
@@ -1,0 +1,151 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} (
+  run_id TIMESTAMP_NTZ
+);
+
+INSERT INTO {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+  SELECT
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ
+  WHERE
+    (SELECT run_id FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} LIMIT 1) IS NULL;
+
+-- Permanent metadata table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}} (
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+-- Setup temp metadata tables for this run
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sv_metadata_this_run{{.entropy}} (
+  id                         VARCHAR(64),
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+INSERT INTO {{.scratch_schema}}.mobile_sv_metadata_this_run{{.entropy}} (
+  SELECT
+    'run',
+    run_id,
+    '{{.model_version}}',
+    'mobile',
+    'screen-views',
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+);
+
+-- Create screen views table if it doesn't exist
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.mobile_screen_views{{.entropy}} (
+
+  screen_view_id VARCHAR(36) NOT NULL,
+  event_id VARCHAR(36),
+  app_id VARCHAR(255),
+  user_id VARCHAR(255),
+  device_user_id VARCHAR(4096),
+  network_userid VARCHAR(128),
+  session_id VARCHAR(36),
+  session_index INT,
+  previous_session_id VARCHAR(36),
+  session_first_event_id VARCHAR(36),
+  screen_view_in_session_index INT,
+  screen_views_in_session INT,
+  dvce_created_tstamp TIMESTAMP_NTZ,
+  collector_tstamp TIMESTAMP_NTZ,
+  derived_tstamp TIMESTAMP_NTZ,
+  model_tstamp TIMESTAMP_NTZ,
+  screen_view_name VARCHAR,
+  screen_view_transition_type VARCHAR,
+  screen_view_type VARCHAR,
+  screen_fragment VARCHAR,
+  screen_top_view_controller VARCHAR,
+  screen_view_controller VARCHAR,
+  screen_view_previous_id VARCHAR(36),
+  screen_view_previous_name VARCHAR,
+  screen_view_previous_type VARCHAR,
+  platform VARCHAR(255),
+  dvce_screenwidth INT,
+  dvce_screenheight INT,
+  device_manufacturer VARCHAR,
+  device_model VARCHAR,
+  os_type VARCHAR,
+  os_version VARCHAR,
+  android_idfa VARCHAR,
+  apple_idfa VARCHAR,
+  apple_idfv VARCHAR,
+  open_idfa VARCHAR,
+  device_latitude FLOAT,
+  device_longitude FLOAT,
+  device_latitude_longitude_accuracy FLOAT,
+  device_altitude FLOAT,
+  device_altitude_accuracy FLOAT,
+  device_bearing FLOAT,
+  device_speed FLOAT,
+  geo_country VARCHAR(2),
+  geo_region VARCHAR(3),
+  geo_city VARCHAR(75),
+  geo_zipcode VARCHAR(15),
+  geo_latitude FLOAT,
+  geo_longitude FLOAT,
+  geo_region_name VARCHAR(100),
+  geo_timezone VARCHAR(64),
+  user_ipaddress VARCHAR(128),
+  useragent VARCHAR(1000),
+  carrier VARCHAR,
+  network_technology VARCHAR,
+  network_type VARCHAR(255),
+  build VARCHAR(255),
+  version VARCHAR(255)
+
+);
+
+-- Create staging table - acts as input to sessions step
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_screen_views_staged{{.entropy}}
+  LIKE {{.output_schema}}.mobile_screen_views{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/01-screen-views.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/01-screen-views.sql
@@ -1,0 +1,183 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_screen_views_this_run{{.entropy}}
+AS (
+  WITH screen_views AS (
+    SELECT
+      e.screen_view_id,
+      e.event_id,
+
+      e.app_id,
+
+      e.user_id,
+      e.device_user_id,
+      e.network_userid,
+
+      e.session_id,
+      e.session_index,
+      e.previous_session_id,
+      e.session_first_event_id,
+
+      e.dvce_created_tstamp,
+      e.collector_tstamp,
+      e.derived_tstamp,
+
+      e.screen_view_name,
+      e.screen_view_transition_type,
+      e.screen_view_type,
+      e.screen_fragment,
+      e.screen_top_view_controller,
+      e.screen_view_controller,
+      e.screen_view_previous_id,
+      e.screen_view_previous_name,
+      e.screen_view_previous_type,
+
+      e.platform,
+      e.dvce_screenwidth,
+      e.dvce_screenheight,
+      e.device_manufacturer,
+      e.device_model,
+      e.os_type,
+      e.os_version,
+      e.android_idfa,
+      e.apple_idfa,
+      e.apple_idfv,
+      e.open_idfa,
+
+      e.device_latitude,
+      e.device_longitude,
+      e.device_latitude_longitude_accuracy,
+      e.device_altitude,
+      e.device_altitude_accuracy,
+      e.device_bearing,
+      e.device_speed,
+      e.geo_country,
+      e.geo_region,
+      e.geo_city,
+      e.geo_zipcode,
+      e.geo_latitude,
+      e.geo_longitude,
+      e.geo_region_name,
+      e.geo_timezone,
+
+      e.user_ipaddress,
+
+      e.useragent,
+
+      e.carrier,
+      e.network_technology,
+      e.network_type,
+
+      e.build,
+      e.version
+
+    FROM 
+      {{.scratch_schema}}.mobile_events_staged{{.entropy}} e
+   
+    WHERE 
+      e.event_name = 'screen_view'
+      AND e.screen_view_id IS NOT NULL
+
+    QUALIFY
+      ROW_NUMBER() OVER (PARTITION BY e.screen_view_id ORDER BY e.derived_tstamp) = 1 --take first screen_view_id
+  )
+
+  , deduped_screen_views AS (
+    SELECT
+      s.*,
+      ROW_NUMBER() OVER (PARTITION BY s.session_id ORDER BY s.derived_tstamp) AS screen_view_in_session_index
+
+    FROM
+      screen_views s
+    )
+
+  SELECT
+    d.screen_view_id,
+    d.event_id,
+
+    d.app_id,
+
+    d.user_id,
+    d.device_user_id,
+    d.network_userid,
+
+    d.session_id,
+    d.session_index,
+    d.previous_session_id,
+    d.session_first_event_id,
+
+    d.screen_view_in_session_index,
+    MAX(d.screen_view_in_session_index) OVER (PARTITION BY d.session_id) AS screen_views_in_session,
+
+    d.dvce_created_tstamp,
+    d.collector_tstamp,
+    d.derived_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS model_tstamp,
+
+    d.screen_view_name,
+    d.screen_view_transition_type,
+    d.screen_view_type,
+    d.screen_fragment,
+    d.screen_top_view_controller,
+    d.screen_view_controller,
+    d.screen_view_previous_id,
+    d.screen_view_previous_name,
+    d.screen_view_previous_type,
+
+    d.platform,
+    d.dvce_screenwidth,
+    d.dvce_screenheight,
+    d.device_manufacturer,
+    d.device_model,
+    d.os_type,
+    d.os_version,
+    d.android_idfa,
+    d.apple_idfa,
+    d.apple_idfv,
+    d.open_idfa,
+
+    d.device_latitude,
+    d.device_longitude,
+    d.device_latitude_longitude_accuracy,
+    d.device_altitude,
+    d.device_altitude_accuracy,
+    d.device_bearing,
+    d.device_speed,
+    d.geo_country,
+    d.geo_region,
+    d.geo_city,
+    d.geo_zipcode,
+    d.geo_latitude,
+    d.geo_longitude,
+    d.geo_region_name,
+    d.geo_timezone,
+
+    d.user_ipaddress,
+
+    d.useragent,
+
+    d.carrier,
+    d.network_technology,
+    d.network_type,
+
+    d.build,
+    d.version
+
+  FROM
+    deduped_screen_views AS d
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/02-screen-views-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/02-screen-views-metadata.sql
@@ -1,0 +1,45 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sv_run_metadata_temp{{.entropy}}
+AS (
+  SELECT
+    'run' AS id,
+    COUNT(*) AS rows_this_run,
+    'screen_view_id' AS distinct_key,
+    COUNT(DISTINCT screen_view_id) AS distinct_key_count,
+    'derived_tstamp' AS time_key,
+    MIN(derived_tstamp) AS min_time_key,
+    MAX(derived_tstamp) AS max_time_key
+
+  FROM
+    {{.scratch_schema}}.mobile_screen_views_this_run{{.entropy}}
+);
+
+UPDATE {{.scratch_schema}}.mobile_sv_metadata_this_run{{.entropy}}
+  SET
+    rows_this_run = b.rows_this_run,
+    distinct_key = b.distinct_key,
+    distinct_key_count = b.distinct_key_count,
+    time_key = b.time_key,
+    min_time_key = b.min_time_key,
+    max_time_key = b.max_time_key
+  FROM
+    {{.scratch_schema}}.mobile_sv_run_metadata_temp{{.entropy}} AS b
+  WHERE
+    {{.scratch_schema}}.mobile_sv_metadata_this_run{{.entropy}}.id = b.id;
+

--- a/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/03-commit-screen-views.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/01-main/03-commit-screen-views.sql
@@ -1,0 +1,62 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- staged tables
+{{if eq .stage_next true}}
+
+  CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',                      -- source schema
+                                       'mobile_screen_views_this_run{{.entropy}}', -- source table
+                                       '{{.scratch_schema}}',                      -- target schema
+                                       'mobile_screen_views_staged{{.entropy}}',   -- target table
+                                       'screen_view_id',                           -- join key
+                                       'derived_tstamp',                           -- partition key
+                                        FALSE);                                    -- automigrate
+
+{{end}}
+
+-- production tables
+{{if ne (or .skip_derived false) true}}
+
+  CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',                      -- source schema
+                                       'mobile_screen_views_this_run{{.entropy}}', -- source table
+                                       '{{.output_schema}}',                       -- target schema
+                                       'mobile_screen_views{{.entropy}}',          -- target table
+                                       'screen_view_id',                           -- join key
+                                       'derived_tstamp',                           -- partition key
+                                        FALSE);                                    -- automigrate
+
+{{end}}
+
+-- commit metadata
+INSERT INTO {{.output_schema}}.datamodel_metadata{{.entropy}}
+  SELECT
+    run_id,
+    model_version,
+    model,
+    module,
+    run_start_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS run_end_tstamp,
+    rows_this_run,
+    distinct_key,
+    distinct_key_count,
+    time_key,
+    min_time_key,
+    max_time_key,
+    duplicate_rows_removed,
+    distinct_keys_removed
+  FROM
+    {{.scratch_schema}}.mobile_sv_metadata_this_run{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/99-complete/99-screen-views-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/99-complete/99-screen-views-cleanup.sql
@@ -1,0 +1,37 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+{{if eq .cleanup_mode "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sv_metadata_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sv_run_metadata_temp{{.entropy}};
+
+{{end}}
+
+
+{{if eq .cleanup_mode "debug" "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_screen_views_this_run{{.entropy}};
+  DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+{{end}}
+
+{{if eq .ends_run true}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}};
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/XX-destroy/XX-destroy-screen-views.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/02-screen-views/XX-destroy/XX-destroy-screen-views.sql
@@ -1,0 +1,40 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+DROP TABLE IF EXISTS {{.output_schema}}.mobile_screen_views{{.entropy}};
+DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_screen_views_staged{{.entropy}};
+
+-- Snowflake supports overloading of procedure names.
+-- So the data types of the arguments are needed to identify the procedure to drop.
+DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.column_checker(VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.alter_table(VARCHAR,
+                                                        VARCHAR,
+                                                        VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.commit_table(VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         BOOLEAN);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/00-setup-app-errors.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/00-setup-app-errors.sql
@@ -1,0 +1,166 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+{{if eq (or .enabled false) true}}
+
+  CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} (
+    run_id TIMESTAMP_NTZ
+  );
+
+  INSERT INTO {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+    SELECT
+      CURRENT_TIMESTAMP::TIMESTAMP_NTZ
+    WHERE
+      (SELECT run_id FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} LIMIT 1) IS NULL;
+
+  -- Permanent metadata table
+  CREATE TABLE IF NOT EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}} (
+    run_id                     TIMESTAMP_NTZ,
+    model_version              VARCHAR(64),
+    model                      VARCHAR(64),
+    module                     VARCHAR(64),
+    run_start_tstamp           TIMESTAMP_NTZ,
+    run_end_tstamp             TIMESTAMP_NTZ,
+    rows_this_run              INTEGER,
+    distinct_key               VARCHAR(64),
+    distinct_key_count         INTEGER,
+    time_key                   VARCHAR(64),
+    min_time_key               TIMESTAMP_NTZ,
+    max_time_key               TIMESTAMP_NTZ,
+    duplicate_rows_removed     INTEGER,
+    distinct_keys_removed      INTEGER
+  );
+
+  -- Setup temp metadata tables for this run
+  CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_app_errors_metadata_this_run{{.entropy}} (
+    id                         VARCHAR(64),
+    run_id                     TIMESTAMP_NTZ,
+    model_version              VARCHAR(64),
+    model                      VARCHAR(64),
+    module                     VARCHAR(64),
+    run_start_tstamp           TIMESTAMP_NTZ,
+    run_end_tstamp             TIMESTAMP_NTZ,
+    rows_this_run              INTEGER,
+    distinct_key               VARCHAR(64),
+    distinct_key_count         INTEGER,
+    time_key                   VARCHAR(64),
+    min_time_key               TIMESTAMP_NTZ,
+    max_time_key               TIMESTAMP_NTZ,
+    duplicate_rows_removed     INTEGER,
+    distinct_keys_removed      INTEGER
+  );
+
+  INSERT INTO {{.scratch_schema}}.mobile_app_errors_metadata_this_run{{.entropy}} (
+    SELECT
+      'run',
+      run_id,
+      '{{.model_version}}',
+      'mobile',
+      'app-errors',
+      CURRENT_TIMESTAMP::TIMESTAMP_NTZ,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL
+    FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+  );
+
+{{end}}
+
+
+-- Reversing usual order as derived output is optional but staging is not.
+-- Staging table always created even if module disabled. This allows for joins downstream.
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_app_errors_staged{{.entropy}} (
+
+  event_id VARCHAR(36) NOT NULL,
+  app_id VARCHAR(255),
+  user_id VARCHAR(255),
+  device_user_id VARCHAR(4096),
+  network_userid VARCHAR(128),
+  session_id VARCHAR(36),
+  session_index INT,
+  previous_session_id VARCHAR(36),
+  session_first_event_id VARCHAR(36),
+  dvce_created_tstamp TIMESTAMP_NTZ,
+  collector_tstamp TIMESTAMP_NTZ,
+  derived_tstamp TIMESTAMP_NTZ,
+  model_tstamp TIMESTAMP_NTZ,
+  platform VARCHAR(255),
+  dvce_screenwidth INT,
+  dvce_screenheight INT,
+  device_manufacturer VARCHAR(4096),
+  device_model VARCHAR(4096),
+  os_type VARCHAR(4096),
+  os_version VARCHAR(4096),
+  android_idfa VARCHAR(4096),
+  apple_idfa VARCHAR(4096),
+  apple_idfv VARCHAR(4096),
+  open_idfa VARCHAR(4096),
+  screen_id VARCHAR(36),
+  screen_name VARCHAR,
+  screen_activity VARCHAR,
+  screen_fragment VARCHAR,
+  screen_top_view_controller VARCHAR,
+  screen_type VARCHAR,
+  screen_view_controller VARCHAR,
+  device_latitude DOUBLE PRECISION,
+  device_longitude DOUBLE PRECISION,
+  device_latitude_longitude_accuracy DOUBLE PRECISION,
+  device_altitude DOUBLE PRECISION,
+  device_altitude_accuracy DOUBLE PRECISION,
+  device_bearing DOUBLE PRECISION,
+  device_speed DOUBLE PRECISION,
+  geo_country VARCHAR(2),
+  geo_region VARCHAR(3),
+  geo_city VARCHAR(75),
+  geo_zipcode VARCHAR(15),
+  geo_latitude DOUBLE PRECISION,
+  geo_longitude DOUBLE PRECISION,
+  geo_region_name VARCHAR(100),
+  geo_timezone VARCHAR(64),
+  user_ipaddress VARCHAR(128),
+  useragent VARCHAR(1000),
+  carrier VARCHAR,
+  network_technology VARCHAR,
+  network_type VARCHAR(255),
+  build VARCHAR(255),
+  version VARCHAR(255),
+  event_index_in_session INT,
+  message VARCHAR(2048),
+  programming_language VARCHAR(255),
+  class_name VARCHAR(1024),
+  exception_name VARCHAR(1024),
+  is_fatal BOOLEAN,
+  line_number INT,
+  stack_trace VARCHAR(8192),
+  thread_id INT,
+  thread_name VARCHAR(1024)
+
+);
+
+{{if eq (or .enabled false) true}}
+  {{if ne (or .skip_derived false) true}}
+
+  CREATE TABLE IF NOT EXISTS {{.output_schema}}.mobile_app_errors{{.entropy}}
+    LIKE {{.scratch_schema}}.mobile_app_errors_staged{{.entropy}};
+
+  {{end}}
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/01-app-errors.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/01-app-errors.sql
@@ -1,0 +1,110 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+{{if eq (or .enabled false) true}}
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_app_errors_this_run{{.entropy}}
+AS (
+  SELECT
+    e.event_id,
+
+    e.app_id,
+
+    e.user_id,
+    e.device_user_id,
+    e.network_userid,
+
+    e.session_id,
+    e.session_index,
+    e.previous_session_id,
+    e.session_first_event_id,
+
+    e.dvce_created_tstamp,
+    e.collector_tstamp,
+    e.derived_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS model_tstamp,
+
+    e.platform,
+    e.dvce_screenwidth,
+    e.dvce_screenheight,
+    e.device_manufacturer,
+    e.device_model,
+    e.os_type,
+    e.os_version,
+    e.android_idfa,
+    e.apple_idfa,
+    e.apple_idfv,
+    e.open_idfa,
+
+    e.screen_id,
+    e.screen_name,
+    e.screen_activity,
+    e.screen_fragment,
+    e.screen_top_view_controller,
+    e.screen_type,
+    e.screen_view_controller,
+
+    e.device_latitude,
+    e.device_longitude,
+    e.device_latitude_longitude_accuracy,
+    e.device_altitude,
+    e.device_altitude_accuracy,
+    e.device_bearing,
+    e.device_speed,
+
+    e.geo_country,
+    e.geo_region,
+    e.geo_city,
+    e.geo_zipcode,
+    e.geo_latitude,
+    e.geo_longitude,
+    e.geo_region_name,
+    e.geo_timezone,
+
+    e.user_ipaddress,
+
+    e.useragent,
+
+    e.carrier,
+    e.network_technology,
+    e.network_type,
+
+    e.build,
+    e.version,
+    e.event_index_in_session,
+
+        --Error details
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:message::VARCHAR(2048) AS message,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:programmingLanguage::VARCHAR(255) AS programming_language,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:className::VARCHAR(1024) AS class_name,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:exceptionName::VARCHAR(1024) AS exception_name,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:isFatal::BOOLEAN AS is_fatal,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:lineNumber::INT AS line_number,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:stackTrace::VARCHAR(8192) AS stack_trace,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:threadId::INT AS thread_id,
+    e.unstruct_event_com_snowplowanalytics_snowplow_application_error_1:threadName::VARCHAR(1024) AS thread_name
+
+    FROM
+      {{.scratch_schema}}.mobile_events_staged{{.entropy}} e
+    WHERE 
+      e.event_name = 'application_error'
+);
+
+{{else}}
+  
+  SELECT 1;
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/02-app-errors-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/02-app-errors-metadata.sql
@@ -1,0 +1,52 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+{{if eq (or .enabled false) true}}
+
+  CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_app_errors_run_metadata_temp{{.entropy}}
+  AS (
+    SELECT
+      'run' AS id,
+      COUNT(*) AS rows_this_run,
+      'event_id' AS distinct_key,
+      COUNT(DISTINCT event_id) AS distinct_key_count,
+      'derived_tstamp' AS time_key,
+      MIN(derived_tstamp) AS min_time_key,
+      MAX(derived_tstamp) AS max_time_key
+
+    FROM
+      {{.scratch_schema}}.mobile_app_errors_this_run{{.entropy}}
+  );
+
+  UPDATE {{.scratch_schema}}.mobile_app_errors_metadata_this_run{{.entropy}}
+    SET
+      rows_this_run = b.rows_this_run,
+      distinct_key = b.distinct_key,
+      distinct_key_count = b.distinct_key_count,
+      time_key = b.time_key,
+      min_time_key = b.min_time_key,
+      max_time_key = b.max_time_key
+    FROM
+      {{.scratch_schema}}.mobile_app_errors_run_metadata_temp{{.entropy}} AS b
+    WHERE
+      {{.scratch_schema}}.mobile_app_errors_metadata_this_run{{.entropy}}.id = b.id;
+
+{{else}}
+
+  SELECT 1;
+
+{{end}}
+

--- a/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/03-commit-app-errors.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/01-main/03-commit-app-errors.sql
@@ -1,0 +1,68 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+{{if eq (or .enabled false) true}}
+  -- staged tables
+  {{if eq .stage_next true}}
+
+    CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',                    -- source schema
+                                         'mobile_app_errors_this_run{{.entropy}}', -- source table
+                                         '{{.scratch_schema}}',                    -- target schema
+                                         'mobile_app_errors_staged{{.entropy}}',   -- target table
+                                         'event_id',                               -- join key
+                                         'derived_tstamp',                         -- partition key
+                                          FALSE);                                  -- automigrate
+
+  {{end}}
+
+  -- production tables
+  {{if ne (or .skip_derived false) true}}
+
+    CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',                    -- source schema
+                                         'mobile_app_errors_this_run{{.entropy}}', -- source table
+                                         '{{.output_schema}}',                     -- target schema
+                                         'mobile_app_errors{{.entropy}}',          -- target table
+                                         'event_id',                               -- join key
+                                         'derived_tstamp',                         -- partition key
+                                          FALSE);                                  -- automigrate
+
+  {{end}}
+
+  -- commit metadata
+  INSERT INTO {{.output_schema}}.datamodel_metadata{{.entropy}}
+    SELECT
+      run_id,
+      model_version,
+      model,
+      module,
+      run_start_tstamp,
+      CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS run_end_tstamp,
+      rows_this_run,
+      distinct_key,
+      distinct_key_count,
+      time_key,
+      min_time_key,
+      max_time_key,
+      duplicate_rows_removed,
+      distinct_keys_removed
+    FROM
+      {{.scratch_schema}}.mobile_app_errors_metadata_this_run{{.entropy}};
+
+{{else}}
+
+  SELECT 1;
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/99-complete/99-app-errors-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/99-complete/99-app-errors-cleanup.sql
@@ -1,0 +1,37 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+{{if eq .cleanup_mode "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_app_errors_metadata_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_app_errors_run_metadata_temp{{.entropy}};
+
+{{end}}
+
+
+{{if eq .cleanup_mode "debug" "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_app_errors_this_run{{.entropy}};
+  DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+{{end}}
+
+{{if eq .ends_run true}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}};
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/XX-destroy/XX-destroy-app-errors.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/03-optional-modules/01-app-errors/XX-destroy/XX-destroy-app-errors.sql
@@ -1,0 +1,40 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+DROP TABLE IF EXISTS {{.output_schema}}.mobile_app_errors{{.entropy}};
+DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_app_errors_staged{{.entropy}};
+
+-- Snowflake supports overloading of procedure names.
+-- So the data types of the arguments are needed to identify the procedure to drop.
+DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.column_checker(VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.alter_table(VARCHAR,
+                                                        VARCHAR,
+                                                        VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.commit_table(VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         BOOLEAN);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/00-setup-sessions.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/00-setup-sessions.sql
@@ -1,0 +1,159 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- A table storing an identifier for this run of a model - used to identify runs of the model across multiple modules/steps (eg. base, page views share this id per run)
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} (
+  run_id TIMESTAMP_NTZ
+);
+
+INSERT INTO {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+  SELECT
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ
+  WHERE
+    (SELECT run_id FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} LIMIT 1) IS NULL;
+
+
+-- Permanent metadata table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}} (
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+
+-- Setup temp metadata tables for this run
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sessions_metadata_this_run{{.entropy}} (
+  id                         VARCHAR(64),
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+INSERT INTO {{.scratch_schema}}.mobile_sessions_metadata_this_run{{.entropy}} (
+  SELECT
+    'run',
+    run_id,
+    '{{.model_version}}',
+    'mobile',
+    'sessions',
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+);
+
+-- Setup Sessions table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.mobile_sessions{{.entropy}} (
+  app_id VARCHAR(255),
+  session_id VARCHAR(36) NOT NULL,
+  session_index INT,
+  previous_session_id VARCHAR(36),
+  session_first_event_id VARCHAR(36),
+  session_last_event_id VARCHAR(36),
+  start_tstamp TIMESTAMP_NTZ,
+  end_tstamp TIMESTAMP_NTZ,
+  model_tstamp TIMESTAMP_NTZ,
+  user_id VARCHAR(255),
+  device_user_id VARCHAR(4096),
+  network_userid VARCHAR(128),
+  session_duration_s INT,
+  has_install BOOLEAN,
+  screen_views INT,
+  screen_names_viewed INT,
+  app_errors INT,
+  fatal_app_errors INT,
+  first_event_name VARCHAR(1000),
+  last_event_name VARCHAR(1000),
+  first_screen_view_name VARCHAR,
+  first_screen_view_transition_type VARCHAR,
+  first_screen_view_type VARCHAR,
+  last_screen_view_name VARCHAR,
+  last_screen_view_transition_type VARCHAR,
+  last_screen_view_type VARCHAR,
+  platform VARCHAR(255),
+  dvce_screenwidth INT,
+  dvce_screenheight INT,
+  device_manufacturer VARCHAR,
+  device_model VARCHAR,
+  os_type VARCHAR,
+  os_version VARCHAR,
+  android_idfa VARCHAR,
+  apple_idfa VARCHAR,
+  apple_idfv VARCHAR,
+  open_idfa VARCHAR,
+  device_latitude FLOAT,
+  device_longitude FLOAT,
+  device_latitude_longitude_accuracy FLOAT,
+  device_altitude FLOAT,
+  device_altitude_accuracy FLOAT,
+  device_bearing FLOAT,
+  device_speed FLOAT,
+  geo_country VARCHAR(2),
+  geo_region VARCHAR(3),
+  geo_city VARCHAR(75),
+  geo_zipcode VARCHAR(15),
+  geo_latitude FLOAT,
+  geo_longitude FLOAT,
+  geo_region_name VARCHAR(100),
+  geo_timezone VARCHAR(64),
+  user_ipaddress VARCHAR(128),
+  useragent VARCHAR(1000),
+  name_tracker VARCHAR(128),
+  v_tracker VARCHAR(100),
+  carrier VARCHAR,
+  network_technology VARCHAR,
+  network_type VARCHAR(255),
+  first_build VARCHAR(255),
+  last_build VARCHAR(255),
+  first_version VARCHAR(255),
+  last_version VARCHAR(255)
+);
+
+-- Staged manifest table as input to users step
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_sessions_userid_manifest_staged{{.entropy}} (
+  device_user_id VARCHAR(4096),
+  start_tstamp TIMESTAMP_NTZ
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/01-sessions-aggs.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/01-sessions-aggs.sql
@@ -1,0 +1,84 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sessions_aggregates{{.entropy}}
+AS (
+  WITH events AS (
+    SELECT
+      es.session_id,
+      es.event_id,
+      es.event_name,
+      es.derived_tstamp,
+      es.build,
+      es.version,
+      es.event_index_in_session,
+      MAX(es.event_index_in_session) OVER (PARTITION BY es.session_id) AS events_in_session
+
+    FROM
+      {{.scratch_schema}}.mobile_events_staged{{.entropy}} es
+  )
+
+  , session_aggs AS (
+    SELECT
+      e.session_id,
+      --last dimensions
+      MAX(CASE WHEN e.event_index_in_session = e.events_in_session THEN e.build END) AS last_build,
+      MAX(CASE WHEN e.event_index_in_session = e.events_in_session THEN e.version END) AS last_version,
+      MAX(CASE WHEN e.event_index_in_session = e.events_in_session THEN e.event_name END) AS last_event_name,
+      MAX(CASE WHEN e.event_index_in_session = e.events_in_session THEN e.event_id END) AS session_last_event_id,
+      -- time
+      MIN(e.derived_tstamp) AS start_tstamp,
+      MAX(e.derived_tstamp) AS end_tstamp,
+      BOOLOR_AGG(e.event_name = 'application_install') has_install
+
+    FROM
+      events e
+
+    GROUP BY 1
+    )
+
+  , app_errors AS (
+    SELECT
+      ae.session_id,
+      COUNT(DISTINCT ae.event_id) AS app_errors,
+      COUNT(DISTINCT CASE WHEN ae.is_fatal THEN ae.event_id END) AS fatal_app_errors
+
+    FROM
+      {{.scratch_schema}}.mobile_app_errors_staged{{.entropy}} ae
+
+    GROUP BY 1
+    )
+
+  SELECT
+    sa.session_id,
+    sa.last_build,
+    sa.last_version,
+    sa.last_event_name,
+    sa.session_last_event_id,
+    sa.start_tstamp,
+    sa.end_tstamp,
+    DATEDIFF(SECOND, sa.start_tstamp, sa.end_tstamp) session_duration_s,
+    sa.has_install,
+    ae.app_errors,
+    ae.fatal_app_errors
+
+  FROM
+    session_aggs sa
+  LEFT JOIN
+    app_errors ae
+  ON sa.session_id = ae.session_id  
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/02-sessions-sv-details.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/02-sessions-sv-details.sql
@@ -1,0 +1,38 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sessions_screen_view_details{{.entropy}}
+AS(
+
+  SELECT
+    sv.session_id,
+    COUNT(DISTINCT sv.screen_view_id) AS screen_views,
+    COUNT(DISTINCT sv.screen_view_name) AS screen_names_viewed,
+    --Could split below into first/last scratch tables. Trying to minimise joins to sessions.
+    MAX(CASE WHEN sv.screen_view_in_session_index = 1 THEN sv.screen_view_name END) AS first_screen_view_name,
+    MAX(CASE WHEN sv.screen_view_in_session_index = 1 THEN sv.screen_view_transition_type END) AS first_screen_view_transition_type,
+    MAX(CASE WHEN sv.screen_view_in_session_index = 1 THEN sv.screen_view_type END) AS first_screen_view_type,
+    MAX(CASE WHEN sv.screen_view_in_session_index = sv.screen_views_in_session THEN sv.screen_view_name END) AS last_screen_view_name,
+    MAX(CASE WHEN sv.screen_view_in_session_index = sv.screen_views_in_session THEN sv.screen_view_transition_type END) AS last_screen_view_transition_type,
+    MAX(CASE WHEN sv.screen_view_in_session_index = sv.screen_views_in_session THEN sv.screen_view_type END) AS last_screen_view_type
+
+  FROM
+    {{.scratch_schema}}.mobile_screen_views_staged{{.entropy}} sv
+
+  GROUP BY 1
+
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/03-sessions.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/03-sessions.sql
@@ -1,0 +1,109 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sessions_this_run{{.entropy}}
+AS (
+  SELECT
+    es.app_id,
+
+    es.session_id,
+    es.session_index,
+    es.previous_session_id,
+    es.session_first_event_id,
+    sa.session_last_event_id,
+
+    sa.start_tstamp,
+    sa.end_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS model_tstamp,
+
+    es.user_id,
+    es.device_user_id,
+    es.network_userid,
+
+    sa.session_duration_s,
+    sa.has_install,
+    sv.screen_views,
+    sv.screen_names_viewed,
+    sa.app_errors,
+    sa.fatal_app_errors,
+
+    es.event_name AS first_event_name,
+    sa.last_event_name,
+
+    sv.first_screen_view_name,
+    sv.first_screen_view_transition_type,
+    sv.first_screen_view_type,
+
+    sv.last_screen_view_name,
+    sv.last_screen_view_transition_type,
+    sv.last_screen_view_type,
+
+    es.platform,
+    es.dvce_screenwidth,
+    es.dvce_screenheight,
+    es.device_manufacturer,
+    es.device_model,
+    es.os_type,
+    es.os_version,
+    es.android_idfa,
+    es.apple_idfa,
+    es.apple_idfv,
+    es.open_idfa,
+
+    es.device_latitude,
+    es.device_longitude,
+    es.device_latitude_longitude_accuracy,
+    es.device_altitude,
+    es.device_altitude_accuracy,
+    es.device_bearing,
+    es.device_speed,
+    es.geo_country,
+    es.geo_region,
+    es.geo_city,
+    es.geo_zipcode,
+    es.geo_latitude,
+    es.geo_longitude,
+    es.geo_region_name,
+    es.geo_timezone,
+
+    es.user_ipaddress,
+
+    es.useragent,
+    es.name_tracker,
+    es.v_tracker,
+
+    es.carrier,
+    es.network_technology,
+    es.network_type,
+    --first/last build/version to measure app updates.
+    es.build AS first_build,
+    sa.last_build,
+    es.version AS first_version,
+    sa.last_version
+
+  FROM
+    {{.scratch_schema}}.mobile_events_staged{{.entropy}} es
+  INNER JOIN 
+    {{.scratch_schema}}.mobile_sessions_aggregates{{.entropy}} sa
+    ON es.session_id = sa.session_id
+  LEFT JOIN --left join as session might not have screen view i.e. app error on opening
+    {{.scratch_schema}}.mobile_sessions_screen_view_details{{.entropy}} sv
+    ON es.session_id = sv.session_id
+
+  WHERE 
+    es.event_index_in_session = 1
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/04-sessions-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/04-sessions-metadata.sql
@@ -1,0 +1,44 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sessions_run_metadata_temp{{.entropy}}
+AS (
+  SELECT
+    'run' AS id,
+    COUNT(*) AS rows_this_run,
+    'session_id' AS distinct_key,
+    COUNT(DISTINCT session_id) AS distinct_key_count,
+    'start_tstamp' AS time_key,
+    MIN(start_tstamp) AS min_time_key,
+    MAX(start_tstamp) AS max_time_key
+
+  FROM
+    {{.scratch_schema}}.mobile_sessions_this_run{{.entropy}}
+);
+
+UPDATE {{.scratch_schema}}.mobile_sessions_metadata_this_run{{.entropy}}
+  SET
+    rows_this_run = b.rows_this_run,
+    distinct_key = b.distinct_key,
+    distinct_key_count = b.distinct_key_count,
+    time_key = b.time_key,
+    min_time_key = b.min_time_key,
+    max_time_key = b.max_time_key
+  FROM
+    {{.scratch_schema}}.mobile_sessions_run_metadata_temp{{.entropy}} AS b
+  WHERE
+    {{.scratch_schema}}.mobile_sessions_metadata_this_run{{.entropy}}.id = b.id;

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/05-sessions-prep-manifest.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/05-sessions-prep-manifest.sql
@@ -1,0 +1,29 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Prep manifest data for users step
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_sessions_userid_manifest_this_run{{.entropy}}
+AS (
+  SELECT
+    device_user_id,
+    MIN(start_tstamp) AS start_tstamp
+
+  FROM
+    {{.scratch_schema}}.mobile_sessions_this_run{{.entropy}}
+
+  GROUP BY 1
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/06-commit-sessions.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/01-main/06-commit-sessions.sql
@@ -1,0 +1,60 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- staged tables
+{{if eq .stage_next true}}
+
+  DELETE FROM {{.scratch_schema}}.mobile_sessions_userid_manifest_staged{{.entropy}}
+      WHERE device_user_id IN (SELECT device_user_id FROM {{.scratch_schema}}.mobile_sessions_userid_manifest_this_run{{.entropy}});
+
+    INSERT INTO {{.scratch_schema}}.mobile_sessions_userid_manifest_staged{{.entropy}}
+      (SELECT * FROM {{.scratch_schema}}.mobile_sessions_userid_manifest_this_run{{.entropy}});
+
+{{end}}
+
+-- production tables
+{{if ne (or .skip_derived false) true}}
+
+  CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',                  -- source schema
+                                       'mobile_sessions_this_run{{.entropy}}', -- source table
+                                       '{{.output_schema}}',                   -- target schema
+                                       'mobile_sessions{{.entropy}}',          -- target table
+                                       'session_id',                           -- join key
+                                       'start_tstamp',                         -- partition key
+                                        FALSE);                                -- automigrate
+
+{{end}}
+
+-- commit metadata
+INSERT INTO {{.output_schema}}.datamodel_metadata{{.entropy}}
+  SELECT
+    run_id,
+    model_version,
+    model,
+    module,
+    run_start_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS run_end_tstamp,
+    rows_this_run,
+    distinct_key,
+    distinct_key_count,
+    time_key,
+    min_time_key,
+    max_time_key,
+    duplicate_rows_removed,
+    distinct_keys_removed
+  FROM
+    {{.scratch_schema}}.mobile_sessions_metadata_this_run{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/99-complete/98-truncate-upstream-staged.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/99-complete/98-truncate-upstream-staged.sql
@@ -1,0 +1,20 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+TRUNCATE TABLE {{.scratch_schema}}.mobile_events_staged{{.entropy}};
+TRUNCATE TABLE {{.scratch_schema}}.mobile_screen_views_staged{{.entropy}};
+TRUNCATE TABLE {{.scratch_schema}}.mobile_app_errors_staged{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/99-complete/99-sessions-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/99-complete/99-sessions-cleanup.sql
@@ -1,0 +1,39 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+{{if eq .cleanup_mode "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_aggregates{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_screen_view_details{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_run_metadata_temp{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_metadata_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_userid_manifest_this_run{{.entropy}};
+
+{{end}}
+
+{{if eq .cleanup_mode "debug" "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_this_run{{.entropy}};
+  DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+{{end}}
+
+{{if eq .ends_run true}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}};
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/XX-destroy/XX-destroy-sessions.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/04-sessions/XX-destroy/XX-destroy-sessions.sql
@@ -1,0 +1,40 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+DROP TABLE IF EXISTS {{.output_schema}}.mobile_sessions{{.entropy}};
+DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_sessions_userid_manifest_staged{{.entropy}};
+
+-- Snowflake supports overloading of procedure names.
+-- So the data types of the arguments are needed to identify the procedure to drop.
+DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.column_checker(VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.alter_table(VARCHAR,
+                                                        VARCHAR,
+                                                        VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.commit_table(VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         BOOLEAN);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/00-setup-users.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/00-setup-users.sql
@@ -1,0 +1,144 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- A table storing an identifier for this run of a model - used to identify runs of the model across multiple modules/steps (eg. base, page views share this id per run)
+CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} (
+  run_id TIMESTAMP_NTZ
+);
+
+INSERT INTO {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+  SELECT
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ
+  WHERE
+    (SELECT run_id FROM {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}} LIMIT 1) IS NULL;
+
+-- Permanent metadata table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.datamodel_metadata{{.entropy}} (
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+-- Setup Metadata
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_metadata_this_run{{.entropy}} (
+  id                         VARCHAR(64),
+  run_id                     TIMESTAMP_NTZ,
+  model_version              VARCHAR(64),
+  model                      VARCHAR(64),
+  module                     VARCHAR(64),
+  run_start_tstamp           TIMESTAMP_NTZ,
+  run_end_tstamp             TIMESTAMP_NTZ,
+  rows_this_run              INTEGER,
+  distinct_key               VARCHAR(64),
+  distinct_key_count         INTEGER,
+  time_key                   VARCHAR(64),
+  min_time_key               TIMESTAMP_NTZ,
+  max_time_key               TIMESTAMP_NTZ,
+  duplicate_rows_removed     INTEGER,
+  distinct_keys_removed      INTEGER
+);
+
+INSERT INTO {{.scratch_schema}}.mobile_users_metadata_this_run{{.entropy}} (
+  SELECT
+    'run',
+    run_id,
+    '{{.model_version}}',
+    'mobile',
+    'users',
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  FROM
+    {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}}
+);
+
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.mobile_users_manifest{{.entropy}} (
+  device_user_id VARCHAR(4096),
+  start_tstamp TIMESTAMP_NTZ
+);
+
+-- Setup Users table
+CREATE TABLE IF NOT EXISTS {{.output_schema}}.mobile_users{{.entropy}} (
+
+  user_id VARCHAR(255),
+  device_user_id VARCHAR(4096),
+  network_userid VARCHAR(128),
+
+  start_tstamp TIMESTAMP_NTZ,
+  end_tstamp TIMESTAMP_NTZ,
+  model_tstamp TIMESTAMP_NTZ,
+
+  screen_views INT,
+  screen_names_viewed INT,
+  sessions INT,
+  sessions_duration_s INT,
+  active_days INT,
+
+  app_errors INT,
+  fatal_app_errors INT,
+
+  first_screen_view_name VARCHAR,
+  first_screen_view_transition_type VARCHAR,
+  first_screen_view_type VARCHAR,
+  last_screen_view_name VARCHAR,
+  last_screen_view_transition_type VARCHAR,
+  last_screen_view_type VARCHAR,
+
+  platform VARCHAR(255),
+  dvce_screenwidth INT,
+  dvce_screenheight INT,
+  device_manufacturer VARCHAR,
+  device_model VARCHAR,
+  os_type VARCHAR,
+  first_os_version VARCHAR,
+  last_os_version VARCHAR,
+  android_idfa VARCHAR,
+  apple_idfa VARCHAR,
+  apple_idfv VARCHAR,
+  open_idfa VARCHAR,
+
+  geo_country VARCHAR(2),
+  geo_region VARCHAR(3),
+  geo_city VARCHAR(75),
+  geo_zipcode VARCHAR(15),
+  geo_latitude FLOAT,
+  geo_longitude FLOAT,
+  geo_region_name VARCHAR(100),
+  geo_timezone VARCHAR(64),
+
+  first_carrier VARCHAR,
+  last_carrier VARCHAR
+    
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/01-userids-this-run.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/01-userids-this-run.sql
@@ -1,0 +1,30 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_userids_this_run{{.entropy}}
+AS (
+  SELECT
+    a.device_user_id,
+    -- LEAST produces NULL if any input value is null
+    LEAST(a.start_tstamp, COALESCE(b.start_tstamp, a.start_tstamp)) AS start_tstamp
+
+  FROM
+    {{.scratch_schema}}.mobile_sessions_userid_manifest_staged{{.entropy}} a
+  LEFT JOIN
+    {{.output_schema}}.mobile_users_manifest{{.entropy}} b
+    ON a.device_user_id = b.device_user_id
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/02-users-limits.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/02-users-limits.sql
@@ -1,0 +1,26 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_limits{{.entropy}}
+AS (
+  SELECT
+    MIN(start_tstamp) AS lower_limit,
+    MAX(start_tstamp) AS upper_limit
+
+  FROM
+    {{.scratch_schema}}.mobile_users_userids_this_run{{.entropy}}
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/03-users-sessions-this-run.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/03-users-sessions-this-run.sql
@@ -1,0 +1,31 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_sessions_this_run{{.entropy}}
+AS (
+  SELECT
+    a.*
+
+  FROM 
+    {{.output_schema}}.mobile_sessions{{.entropy}} a
+  INNER JOIN 
+    {{.scratch_schema}}.mobile_users_userids_this_run{{.entropy}} b
+    ON a.device_user_id = b.device_user_id
+
+  WHERE a.start_tstamp >= (SELECT lower_limit FROM {{.scratch_schema}}.mobile_users_limits{{.entropy}})
+    AND a.start_tstamp <= (SELECT upper_limit FROM {{.scratch_schema}}.mobile_users_limits{{.entropy}})
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/04-users-aggs.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/04-users-aggs.sql
@@ -1,0 +1,39 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_aggregates{{.entropy}}
+AS (
+  SELECT
+    device_user_id,
+    -- time
+    MIN(start_tstamp) AS start_tstamp,
+    MAX(end_tstamp) AS end_tstamp,
+    -- engagement
+    SUM(screen_views) AS screen_views,
+    SUM(screen_names_viewed) AS screen_names_viewed,
+    COUNT(DISTINCT session_id) AS sessions,
+    SUM(session_duration_s) AS sessions_duration_s,
+    COUNT(DISTINCT DATE(start_tstamp)) AS active_days,
+    --errors
+    SUM(app_errors) AS app_errors,
+    SUM(fatal_app_errors) AS fatal_app_errors
+
+  FROM 
+    {{.scratch_schema}}.mobile_users_sessions_this_run{{.entropy}}
+
+  GROUP BY 1
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/05-users-lasts.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/05-users-lasts.sql
@@ -1,0 +1,36 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_lasts{{.entropy}}
+AS (
+  SELECT
+    a.device_user_id,
+    a.last_screen_view_name,
+    a.last_screen_view_transition_type,
+    a.last_screen_view_type,
+
+    a.carrier AS last_carrier,
+    a.os_version AS last_os_version
+
+  FROM
+    {{.scratch_schema}}.mobile_users_sessions_this_run{{.entropy}} a
+
+  INNER JOIN 
+    {{.scratch_schema}}.mobile_users_aggregates{{.entropy}} b
+    ON a.device_user_id = b.device_user_id
+    AND a.end_tstamp = b.end_tstamp
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/06-users.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/06-users.sql
@@ -1,0 +1,87 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_this_run{{.entropy}}
+AS (
+  SELECT
+    -- user fields
+    a.user_id,
+    a.device_user_id,
+    a.network_userid,
+
+    b.start_tstamp,
+    b.end_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS model_tstamp,
+
+    -- engagement fields
+    b.screen_views,
+    b.screen_names_viewed,
+    b.sessions,
+    b.sessions_duration_s,
+    b.active_days,
+    --errors
+    b.app_errors,
+    b.fatal_app_errors,
+
+    -- screen fields
+    a.first_screen_view_name,
+    a.first_screen_view_transition_type,
+    a.first_screen_view_type,
+
+    c.last_screen_view_name,
+    c.last_screen_view_transition_type,
+    c.last_screen_view_type,
+
+    -- device fields
+    a.platform,
+    a.dvce_screenwidth,
+    a.dvce_screenheight,
+    a.device_manufacturer,
+    a.device_model,
+    a.os_type,
+    a.os_version first_os_version,
+    c.last_os_version,
+    a.android_idfa,
+    a.apple_idfa,
+    a.apple_idfv,
+    a.open_idfa,
+
+    -- geo fields
+    a.geo_country,
+    a.geo_region,
+    a.geo_city,
+    a.geo_zipcode,
+    a.geo_latitude,
+    a.geo_longitude,
+    a.geo_region_name,
+    a.geo_timezone,
+
+    a.carrier first_carrier,
+    c.last_carrier
+
+  FROM 
+    {{.scratch_schema}}.mobile_users_aggregates{{.entropy}} AS b
+
+  INNER JOIN 
+    {{.scratch_schema}}.mobile_users_sessions_this_run{{.entropy}} AS a
+    ON a.device_user_id = b.device_user_id
+    AND a.start_tstamp = b.start_tstamp
+
+  INNER JOIN 
+    {{.scratch_schema}}.mobile_users_lasts{{.entropy}} c
+    ON b.device_user_id = c.device_user_id
+);

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/07-users-metadata.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/07-users-metadata.sql
@@ -1,0 +1,44 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_users_run_metadata_temp{{.entropy}}
+AS (
+  SELECT
+    'run' AS id,
+    COUNT(*) AS rows_this_run,
+    'device_user_id' AS distinct_key,
+    COUNT(DISTINCT device_user_id) AS distinct_key_count,
+    'start_tstamp' AS time_key,
+    MIN(start_tstamp) AS min_time_key,
+    MAX(start_tstamp) AS max_time_key
+
+  FROM
+    {{.scratch_schema}}.mobile_users_this_run{{.entropy}}
+);
+
+UPDATE {{.scratch_schema}}.mobile_users_metadata_this_run{{.entropy}}
+  SET
+    rows_this_run = b.rows_this_run,
+    distinct_key = b.distinct_key,
+    distinct_key_count = b.distinct_key_count,
+    time_key = b.time_key,
+    min_time_key = b.min_time_key,
+    max_time_key = b.max_time_key
+  FROM
+    {{.scratch_schema}}.mobile_users_run_metadata_temp{{.entropy}} AS b
+  WHERE
+    {{.scratch_schema}}.mobile_users_metadata_this_run{{.entropy}}.id = b.id;

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/08-commit-users.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/01-main/08-commit-users.sql
@@ -1,0 +1,49 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- production tables
+{{if ne (or .skip_derived false) true}}
+
+  CALL {{.output_schema}}.commit_table('{{.scratch_schema}}',               -- source schema
+                                       'mobile_users_this_run{{.entropy}}', -- source table
+                                       '{{.output_schema}}',                -- target schema
+                                       'mobile_users{{.entropy}}',          -- target table
+                                       'device_user_id',                    -- join key
+                                       'start_tstamp',                      -- partition key
+                                        FALSE);                             -- automigrate
+
+{{end}}
+
+-- commit metadata
+INSERT INTO {{.output_schema}}.datamodel_metadata{{.entropy}}
+  SELECT
+    run_id,
+    model_version,
+    model,
+    module,
+    run_start_tstamp,
+    CURRENT_TIMESTAMP::TIMESTAMP_NTZ AS run_end_tstamp,
+    rows_this_run,
+    distinct_key,
+    distinct_key_count,
+    time_key,
+    min_time_key,
+    max_time_key,
+    duplicate_rows_removed,
+    distinct_keys_removed
+  FROM
+    {{.scratch_schema}}.mobile_users_metadata_this_run{{.entropy}};

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/99-complete/98-manifest-and-truncate.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/99-complete/98-manifest-and-truncate.sql
@@ -1,0 +1,19 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+-- Update manifest and truncate input table just processed
+CALL {{.output_schema}}.update_manifest('users');

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/99-complete/99-users-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/99-complete/99-users-cleanup.sql
@@ -1,0 +1,42 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+
+{{if eq .cleanup_mode "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_aggregates{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_lasts{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_run_metadata_temp{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_metadata_this_run{{.entropy}};
+
+{{end}}
+
+{{if eq .cleanup_mode "debug" "trace"}} SELECT 1; {{else}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_userids_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_limits{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_this_run{{.entropy}};
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_users_sessions_this_run{{.entropy}};
+  DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+{{end}}
+
+{{if eq .ends_run true}}
+
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_metadata_run_id{{.entropy}};
+
+{{end}}

--- a/mobile/v1/snowflake/sql-runner/sql/standard/05-users/XX-destroy/XX-destroy-users.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/05-users/XX-destroy/XX-destroy-users.sql
@@ -1,0 +1,40 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+DROP TABLE IF EXISTS {{.output_schema}}.mobile_users{{.entropy}};
+DROP TABLE IF EXISTS {{.output_schema}}.mobile_users_manifest{{.entropy}};
+
+-- Snowflake supports overloading of procedure names.
+-- So the data types of the arguments are needed to identify the procedure to drop.
+DROP PROCEDURE IF EXISTS {{.output_schema}}.update_manifest(BOOLEAN);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.column_checker(VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR,
+                                                           VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.alter_table(VARCHAR,
+                                                        VARCHAR,
+                                                        VARCHAR);
+
+DROP PROCEDURE IF EXISTS {{.output_schema}}.commit_table(VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         VARCHAR,
+                                                         BOOLEAN);

--- a/mobile/v1/snowflake/sql-runner/sql/tests/00-staging-reconciliation/01-main/00-staging-reconciliation.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/tests/00-staging-reconciliation/01-main/00-staging-reconciliation.sql
@@ -1,0 +1,114 @@
+
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+CREATE OR REPLACE TABLE {{.scratch_schema}}.mobile_staging_reconciliation{{.entropy}}
+AS (
+
+  WITH events AS (
+    SELECT
+      '1' AS _pk,
+      COUNT(DISTINCT event_id) AS distinct_event_ids,
+      SUM(CASE WHEN event_name = 'screen_view' THEN 1 END) AS screen_view_rows,
+      COUNT(DISTINCT CASE WHEN event_name = 'screen_view' THEN event_id END) AS distinct_sv_event_ids,
+      COUNT(DISTINCT session_id) AS distinct_session_ids,
+      SUM(CASE WHEN event_index_in_session = 1 THEN 1 END) AS sessions_rows,
+      COUNT(DISTINCT CASE WHEN event_name = 'screen_view' THEN session_id END) AS distinct_session_ids_w_screen_view,
+      COUNT(DISTINCT CASE WHEN event_name = 'application_error' THEN event_id END) AS app_error_distinct_event_ids,
+      SUM(CASE WHEN event_name = 'application_error' THEN 1 END) AS app_error_row_count
+
+    FROM {{.scratch_schema}}.mobile_events_staged{{.entropy}}
+    GROUP BY 1
+  )
+
+  , screen_views AS (
+    SELECT
+      '1' AS _pk,
+      COUNT(DISTINCT event_id) AS distinct_sv_event_ids,
+      COUNT(DISTINCT screen_view_id) AS distinct_screen_view_ids,
+      COUNT(DISTINCT session_id) AS distinct_session_ids,
+      COUNT(*) AS screen_view_rows
+
+    FROM {{.scratch_schema}}.mobile_screen_views_staged{{.entropy}}
+    GROUP BY 1
+  )
+
+  --Not valid if screen views run multiple times to staging.
+  , screen_view_removed_dupes AS (
+    SELECT
+      '1' AS _pk,
+      COUNT(*) removed_screen_view_rows
+
+    FROM (
+      SELECT
+        e.screen_view_id,
+        ROW_NUMBER() OVER(PARTITION BY e.screen_view_id ORDER BY e.derived_tstamp) AS row_num
+
+      FROM {{.scratch_schema}}.mobile_events_staged e
+      WHERE e.event_name = 'screen_view'
+      AND e.screen_view_id IS NOT NULL)
+    WHERE row_num != 1
+    GROUP BY 1
+  )
+
+  , app_errors AS (
+    SELECT
+      '1' AS _pk,
+      COUNT(DISTINCT event_id) AS distinct_app_errors_event_id,
+      COUNT(*) AS app_error_rows
+
+    FROM {{.scratch_schema}}.mobile_app_errors_staged{{.entropy}}
+    GROUP BY 1
+  )
+
+  , sessions AS (
+    SELECT
+      '1' AS _pk,
+      COUNT(DISTINCT session_id) AS distinct_session_ids,
+      SUM(screen_views) AS distinct_screen_view_ids,
+      COUNT(*) AS sessions_rows,
+      SUM(app_errors) AS app_errors
+
+    FROM {{.scratch_schema}}.mobile_sessions_this_run{{.entropy}}
+    GROUP BY 1
+  )
+
+  SELECT
+    e._pk,
+    IFNULL(e.screen_view_rows,0) - IFNULL(sv.screen_view_rows,0) - IFNULL(svd.removed_screen_view_rows,0) AS ev_to_sv_sv_rows,
+    IFNULL(e.distinct_sv_event_ids,0) - IFNULL(sv.distinct_sv_event_ids,0) AS ev_to_sv_distinct_event_ids,
+    IFNULL(e.sessions_rows,0) - IFNULL(s.sessions_rows,0) AS ev_to_sess_session_rows,
+    IFNULL(e.distinct_session_ids,0) - IFNULL(s.distinct_session_ids,0) AS ev_to_sess_distinct_session_ids,
+    IFNULL(e.distinct_session_ids_w_screen_view,0) - IFNULL(sv.distinct_session_ids,0) AS ev_to_sv_distinct_session_ids,
+    {{if eq (or .app_errors false) true}}
+    --Only evaluate if module enabled
+    IFNULL(e.app_error_distinct_event_ids,0) - IFNULL(ae.distinct_app_errors_event_id,0) AS ev_to_ae_distinct_event_ids,
+    IFNULL(e.app_error_row_count,0) - IFNULL(ae.app_error_rows,0) AS ev_to_ae_row_count,
+    {{else}}
+    0 AS ev_to_ae_distinct_event_ids,
+    0 AS ev_to_ae_row_count,
+    {{end}}
+    IFNULL(sv.distinct_screen_view_ids,0) -IFNULL(s.distinct_screen_view_ids,0) AS sv_to_sess_sv_distinct_screen_view_ids,
+    IFNULL(ae.distinct_app_errors_event_id,0) - IFNULL(s.app_errors,0) AS ae_to_sess_app_errors
+
+  FROM events e
+  LEFT JOIN screen_views sv
+  ON e._pk = sv._pk
+  LEFT JOIN screen_view_removed_dupes svd
+  ON e._pk = svd._pk
+  LEFT JOIN app_errors ae
+  ON e._pk = ae._pk
+  LEFT JOIN sessions s
+  ON e._pk = s._pk
+
+);

--- a/mobile/v1/snowflake/sql-runner/sql/tests/00-staging-reconciliation/99-complete/99-staging-reconciliation-cleanup.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/tests/00-staging-reconciliation/99-complete/99-staging-reconciliation-cleanup.sql
@@ -1,0 +1,16 @@
+/*
+   Copyright 2021 Snowplow Analytics Ltd. All rights reserved.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+{{if eq .cleanup_mode "debug" "trace"}} SELECT 1; {{else}}
+  DROP TABLE IF EXISTS {{.scratch_schema}}.mobile_staging_reconciliation{{.entropy}};
+{{end}}


### PR DESCRIPTION
Couple of points to call out:

- I have added a new procedure, `commit_table`, which replicates the same procedure in GBQ. This is in place of the `commit_staged` which was previously used in the Snowflake web model. I prefer this as it is a more general procedure that can also be used by the users for custom modules.
- I have also modified `column_check`. The `AUTOMIGRATE` input is now a BOOLEAN rather than a VARCHAR. This made more sense to me and again aligns with the GBQ model. The issue here is that this procedures is used in the web model too, and hasnt been updated in that model. However from what I understand Snowflake can have two procedures with the same name but different input types so in theory if the users is running both models the procedures shouldnt clash. Alternatively we could rename this to `column_check_v2` or something, or update the web model. 
- I removed the duplicates step `07-duplicates` in the base module. Given we never actually fully remove dupes, the insert overwrite procedure seemed overkill here just to count how many rows we removed. Again this aligns with GBQ.
- `06-events-this-run`: I removed the stored procedure from the web model that effectively replicates an `EXCEPT` statement in GBQ. Instead, I have chosen to leave in contexts cols like the page_view context. This simplified the logic and can potentially avoid headache later down the line if new fields are added to these columns that are later required.
