### PR TITLE
replace-events-staged-ddl-logic

### DIFF
--- a/web/v1/snowflake/sql-runner/sql/standard/01-base/01-main/00-setup-base.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/01-base/01-main/00-setup-base.sql
@@ -127,7 +127,7 @@ CREATE OR REPLACE PROCEDURE {{.scratch_schema}}.create_events_staged()
   }
 
   var fin_query=`
-    CREATE OR REPLACE TABLE {{.scratch_schema}}.events_staged{{.entropy}}
+    CREATE TABLE IF NOT EXISTS {{.scratch_schema}}.events_staged{{.entropy}}
     AS
       SELECT
         ` + new_col + ` ` + result + `
@@ -136,7 +136,7 @@ CREATE OR REPLACE PROCEDURE {{.scratch_schema}}.create_events_staged()
 
   snowflake.createStatement({sqlText: fin_query}).execute();
 
-  return 'ok. create_events_staged succeeded.';
+  return 'ok. procedure has run successfully';
 
   $$
 ;


### PR DESCRIPTION
Replace scratch.events_staged table DDL logic from CREATE TABLE statement to  a stored procedure.

This will help to fix the se_label column size issue described here: https://github.com/snowplow/data-models/issues/109

and is consistent with the stored procedure used to create the events_this_run table: https://github.com/snowplow/data-models/blob/master/web/v1/snowflake/sql-runner/sql/standard/01-base/01-main/06-events-this-run.sql#L18