### PR TITLE
web/v1 explicit SORTKEY encodings changed to RAW

### DIFF
--- a/web/v1/redshift/sql-runner/sql/standard/02-page-views/01-main/00-setup-page-views.sql
+++ b/web/v1/redshift/sql-runner/sql/standard/02-page-views/01-main/00-setup-page-views.sql
@@ -106,7 +106,7 @@ CREATE TABLE IF NOT EXISTS {{.output_schema}}.page_views{{.entropy}} (
   dvce_created_tstamp TIMESTAMP ENCODE ZSTD,
   collector_tstamp TIMESTAMP ENCODE ZSTD,
   derived_tstamp TIMESTAMP ENCODE ZSTD,
-  start_tstamp TIMESTAMP ENCODE ZSTD,
+  start_tstamp TIMESTAMP ENCODE RAW,
   end_tstamp TIMESTAMP ENCODE ZSTD,
 
   engaged_time_in_s INT ENCODE ZSTD,

--- a/web/v1/redshift/sql-runner/sql/standard/03-sessions/01-main/00-setup-sessions.sql
+++ b/web/v1/redshift/sql-runner/sql/standard/03-sessions/01-main/00-setup-sessions.sql
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS {{.output_schema}}.sessions{{.entropy}} (
   domain_sessionid VARCHAR(128) ENCODE ZSTD,
   domain_sessionidx INT ENCODE ZSTD,
 
-  start_tstamp TIMESTAMP ENCODE ZSTD,
+  start_tstamp TIMESTAMP ENCODE RAW,
   end_tstamp TIMESTAMP ENCODE ZSTD,
 
   -- user fields

--- a/web/v1/redshift/sql-runner/sql/standard/04-users/01-main/00-setup-users.sql
+++ b/web/v1/redshift/sql-runner/sql/standard/04-users/01-main/00-setup-users.sql
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS {{.output_schema}}.users{{.entropy}} (
   domain_userid VARCHAR(128) ENCODE ZSTD,
   network_userid VARCHAR(128) ENCODE ZSTD,
 
-  start_tstamp TIMESTAMP ENCODE ZSTD,
+  start_tstamp TIMESTAMP ENCODE RAW,
   end_tstamp TIMESTAMP ENCODE ZSTD,
 
   page_views INT ENCODE ZSTD,


### PR DESCRIPTION
To remove risk of sortkey skew leading to excessive block I/O with early materialization per
https://github.com/awslabs/amazon-redshift-utils/blob/master/src/Investigations/EarlyMaterialization.md

issue: #129