### PR TITLE
Maintenance/add migrations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
-Redshift Web Version 1.3.0 (2022-06-06)
---------------------------
+Maintenance release (2022-07-21)
+--------------------------------
+Add migrations for previous releases (#133)
+
+Redshift Web Version 1.3.0 (2022-06-07)
+--------------------------------------
 Redshift web: Change SORTKEY encoding to RAW (#129) (thanks @mark-walle!)
 Redshift Web: Fix column lengths in manifest tables (#131)
 

--- a/mobile/v1/bigquery/sql-runner/configs/migrations.json
+++ b/mobile/v1/bigquery/sql-runner/configs/migrations.json
@@ -2,14 +2,10 @@
     "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
     "data": {
         "enabled": true,
-        "storage": "Default",
+        "storage": "Bigquery",
         "playbooks": [
         {
-            "playbook": "standard/99-migrations/1.2.0-migration",
-            "dependsOn": []
-        },
-        {
-            "playbook": "standard/99-migrations/1.3.0-migration",
+            "playbook": "standard/99-migrations/1.1.0-migration",
             "dependsOn": []
         }
         ],

--- a/mobile/v1/bigquery/sql-runner/playbooks/standard/99-migrations/1.1.0-migration.yml.tmpl
+++ b/mobile/v1/bigquery/sql-runner/playbooks/standard/99-migrations/1.1.0-migration.yml.tmpl
@@ -1,0 +1,15 @@
+:targets:
+- :name:
+  :type:    bigquery
+  :project:
+  :region:
+:variables:
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 1.1.0-migration
+  :queries:
+    - :name: mobile-events-staged
+      :file: standard/99-migrations/1.1.0-migration/mobile-events-staged.sql
+      :template: true

--- a/mobile/v1/bigquery/sql-runner/sql/standard/99-migrations/1.1.0-migration/mobile-events-staged.sql
+++ b/mobile/v1/bigquery/sql-runner/sql/standard/99-migrations/1.1.0-migration/mobile-events-staged.sql
@@ -1,0 +1,18 @@
+-- Create Procedure to drop mobile_events_staged if it is empty
+CREATE OR REPLACE PROCEDURE {{.scratch_schema}}.drop_mobile_events_staged_if_empty ()
+BEGIN
+    DECLARE rows_in_table INT64;
+    SET rows_in_table = (SELECT count(*) FROM {{.scratch_schema}}.mobile_events_staged{{.entropy}});
+
+    IF rows_in_table > 0 THEN
+         RAISE USING MESSAGE = 'Ensure that all data has been processed from events_staged and it is empty.';
+    ELSE
+        DROP TABLE {{.scratch_schema}}.mobile_events_staged{{.entropy}};
+    END IF;
+END;
+
+-- Run the procedure
+CALL {{.scratch_schema}}.drop_mobile_events_staged_if_empty();
+
+-- Remove the procedure
+DROP PROCEDURE {{.scratch_schema}}.drop_mobile_events_staged_if_empty;

--- a/mobile/v1/snowflake/sql-runner/configs/migrations.json
+++ b/mobile/v1/snowflake/sql-runner/configs/migrations.json
@@ -2,14 +2,10 @@
     "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
     "data": {
         "enabled": true,
-        "storage": "Default",
+        "storage": "Snowflake",
         "playbooks": [
         {
-            "playbook": "standard/99-migrations/1.2.0-migration",
-            "dependsOn": []
-        },
-        {
-            "playbook": "standard/99-migrations/1.3.0-migration",
+            "playbook": "standard/99-migrations/1.1.0-migration",
             "dependsOn": []
         }
         ],

--- a/mobile/v1/snowflake/sql-runner/playbooks/standard/99-migrations/1.1.0-migration.yml.tmpl
+++ b/mobile/v1/snowflake/sql-runner/playbooks/standard/99-migrations/1.1.0-migration.yml.tmpl
@@ -1,0 +1,18 @@
+:targets:
+- :name:
+  :type:      snowflake
+  :account:
+  :database:
+  :warehouse:
+  :username:
+  :password:
+:variables:
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 1.1.0-migration
+  :queries:
+    - :name: mobile-events-staged
+      :file: standard/99-migrations/1.1.0-migration/mobile-events-staged.sql
+      :template: true

--- a/mobile/v1/snowflake/sql-runner/sql/standard/99-migrations/1.1.0-migration/mobile-events-staged.sql
+++ b/mobile/v1/snowflake/sql-runner/sql/standard/99-migrations/1.1.0-migration/mobile-events-staged.sql
@@ -1,0 +1,42 @@
+-- Create Procedure to drop mobile_events_staged if it is empty
+CREATE OR REPLACE PROCEDURE {{.scratch_schema}}.drop_mobile_events_staged_if_empty()
+  RETURNS VARCHAR
+  LANGUAGE JAVASCRIPT
+  AS
+  $$
+    var getRowCount = snowflake.createStatement(
+           {
+           sqlText: "SELECT count(*) FROM {{.scratch_schema}}.mobile_events_staged{{.entropy}};"
+           }
+        );
+	
+    var res = getRowCount.execute();
+    res.next();
+    row_count = res.getColumnValue(1);
+    if (row_count > 0) {
+        throw "Ensure that all data has been processed from events_staged and it is empty.";
+    }
+    else {
+        try {
+            var getRowCount = snowflake.createStatement(
+                {
+                sqlText: "DROP TABLE {{.scratch_schema}}.mobile_events_staged{{.entropy}};"
+                }
+                );
+
+            var res = getRowCount.execute();
+        }  catch(ERROR) {
+
+            snowflake.createStatement({sqlText: `ROLLBACK;`}).execute();
+            throw ERROR;
+
+        }
+    }
+  $$;
+
+-- Run the procedure
+CALL {{.scratch_schema}}.drop_mobile_events_staged_if_empty();
+
+
+-- Remove the procedure
+DROP PROCEDURE {{.scratch_schema}}.drop_mobile_events_staged_if_empty();

--- a/web/v1/redshift/CHANGELOG
+++ b/web/v1/redshift/CHANGELOG
@@ -1,4 +1,4 @@
-Version 1.3.0 (2022-06-06)
+Version 1.3.0 (2022-06-07)
 --------------------------
 Redshift web: Change SORTKEY encoding to RAW (#129) (thanks @mark-walle!)
 Redshift Web: Fix column lengths in manifest tables (#131)

--- a/web/v1/redshift/sql-runner/playbooks/standard/99-migrations/1.2.0-migration.yml.tmpl
+++ b/web/v1/redshift/sql-runner/playbooks/standard/99-migrations/1.2.0-migration.yml.tmpl
@@ -1,0 +1,19 @@
+:targets:
+- :name:
+  :type:     redshift
+  :host:
+  :database:
+  :port:
+  :username:
+  :password:
+  :ssl:
+:variables:
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 1.2.0-migration
+  :queries:
+    - :name: events-staged
+      :file: standard/99-migrations/1.2.0-migration/events-staged.sql
+      :template: true

--- a/web/v1/redshift/sql-runner/sql/standard/99-migrations/1.2.0-migration/events-staged.sql
+++ b/web/v1/redshift/sql-runner/sql/standard/99-migrations/1.2.0-migration/events-staged.sql
@@ -1,0 +1,20 @@
+-- Define stored procedure so we can do a safety check
+CREATE OR REPLACE PROCEDURE drop_events_staged_if_empty()
+AS $$
+DECLARE
+    rows_in_table int;
+BEGIN
+    SELECT INTO rows_in_table COUNT(*) FROM {{.scratch_schema}}.events_staged{{.entropy}};
+    IF rows_in_table > 0 THEN
+        RAISE EXCEPTION 'Ensure that all data has been processed from events_staged and it is empty.';
+    ELSE
+        DROP TABLE {{.scratch_schema}}.events_staged{{.entropy}};
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Call the procedure
+CALL drop_events_staged_if_empty();
+
+-- Drop the procedure.
+DROP PROCEDURE drop_events_staged_if_empty();

--- a/web/v1/snowflake/sql-runner/configs/migrations.json
+++ b/web/v1/snowflake/sql-runner/configs/migrations.json
@@ -1,0 +1,17 @@
+{
+    "schema": "iglu:com.snowplowanalytics.datamodeling/config/jsonschema/1-0-0",
+    "data": {
+      "dagName": "standard-webmodel",
+      "enabled": true,
+      "storage": "Default",
+      "sqlRunner": "0.9.3",
+      "lockType": "hard",
+      "playbooks": [
+        {
+          "playbook": "standard/99-migrations/1.0.1-migration",
+          "dependsOn": []
+        }
+      ]
+    }
+  }
+  

--- a/web/v1/snowflake/sql-runner/playbooks/standard/99-migrations/1.0.1-migration.yml.tmpl
+++ b/web/v1/snowflake/sql-runner/playbooks/standard/99-migrations/1.0.1-migration.yml.tmpl
@@ -1,0 +1,44 @@
+:targets:
+- :name:
+  :type:     redshift
+  :host:
+  :database:
+  :port:
+  :username:
+  :password:
+  :ssl:
+:variables:
+  :scratch_schema:     scratch
+  :output_schema:      derived
+  :entropy:            ""
+:steps:
+- :name: 1.0.1-migration
+  :queries:
+    - :name: base-session-id-manifest
+      :file: standard/99-migrations/1.0.1-migration/base-session-id-manifest.sql
+      :template: true
+- :name: 1.0.1-migration
+  :queries:
+    - :name: events-staged
+      :file: standard/99-migrations/1.0.1-migration/events-staged.sql
+      :template: true
+- :name: 1.0.1-migration
+  :queries:
+    - :name: users-manifest
+      :file: standard/99-migrations/1.0.1-migration/users-manifest.sql
+      :template: true
+- :name: 1.0.1-migration
+  :queries:
+    - :name: page-views-staged
+      :file: standard/99-migrations/1.0.1-migration/page-views-staged.sql
+      :template: true
+- :name: 1.0.1-migration
+  :queries:
+    - :name: page-views
+      :file: standard/99-migrations/1.0.1-migration/page-views.sql
+      :template: true
+- :name: 1.0.1-migration
+  :queries:
+    - :name: sessions
+      :file: standard/99-migrations/1.0.1-migration/sessions.sql
+      :template: true

--- a/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/base-session-id-manifest.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/base-session-id-manifest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS {{.output_schema}}.base_session_id_manifest{{.entropy}}
+ ALTER COLUMN session_id SET DATA TYPE VARCHAR(128);

--- a/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/events-staged.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/events-staged.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS {{.scratch_schema}}.events_staged{{.entropy}}
+ ALTER COLUMN se_label SET DATA TYPE VARCHAR(4096);

--- a/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/page-views-staged.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/page-views-staged.sql
@@ -1,0 +1,17 @@
+ALTER TABLE IF EXISTS {{.scratch_schema}}.page_views_staged{{.entropy}}
+ ALTER COLUMN agent_name SET DATA TYPE VARCHAR,
+  agent_name_version SET DATA TYPE VARCHAR,
+  agent_name_version_major SET DATA TYPE VARCHAR,
+  agent_version SET DATA TYPE VARCHAR,
+  agent_version_major SET DATA TYPE VARCHAR,
+  device_brand SET DATA TYPE VARCHAR,
+  device_name SET DATA TYPE VARCHAR,
+  device_version SET DATA TYPE VARCHAR,
+  layout_engine_name SET DATA TYPE VARCHAR,
+  layout_engine_name_version SET DATA TYPE VARCHAR,
+  layout_engine_name_version_major SET DATA TYPE VARCHAR,
+  layout_engine_version SET DATA TYPE VARCHAR,
+  layout_engine_version_major SET DATA TYPE VARCHAR,
+  operating_system_name SET DATA TYPE VARCHAR,
+  operating_system_name_version SET DATA TYPE VARCHAR,
+  operating_system_version SET DATA TYPE VARCHAR;

--- a/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/page-views.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/page-views.sql
@@ -1,0 +1,17 @@
+ALTER TABLE IF EXISTS {{.output_schema}}.page_views{{.entropy}}
+ ALTER COLUMN agent_name SET DATA TYPE VARCHAR,
+  agent_name_version SET DATA TYPE VARCHAR,
+  agent_name_version_major SET DATA TYPE VARCHAR,
+  agent_version SET DATA TYPE VARCHAR,
+  agent_version_major SET DATA TYPE VARCHAR,
+  device_brand SET DATA TYPE VARCHAR,
+  device_name SET DATA TYPE VARCHAR,
+  device_version SET DATA TYPE VARCHAR,
+  layout_engine_name SET DATA TYPE VARCHAR,
+  layout_engine_name_version SET DATA TYPE VARCHAR,
+  layout_engine_name_version_major SET DATA TYPE VARCHAR,
+  layout_engine_version SET DATA TYPE VARCHAR,
+  layout_engine_version_major SET DATA TYPE VARCHAR,
+  operating_system_name SET DATA TYPE VARCHAR,
+  operating_system_name_version SET DATA TYPE VARCHAR,
+  operating_system_version SET DATA TYPE VARCHAR;

--- a/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/sessions.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/sessions.sql
@@ -1,0 +1,17 @@
+ALTER TABLE IF EXISTS {{.output_schema}}.sessions{{.entropy}}
+ ALTER COLUMN agent_name SET DATA TYPE VARCHAR,
+  agent_name_version SET DATA TYPE VARCHAR,
+  agent_name_version_major SET DATA TYPE VARCHAR,
+  agent_version SET DATA TYPE VARCHAR,
+  agent_version_major SET DATA TYPE VARCHAR,
+  device_brand SET DATA TYPE VARCHAR,
+  device_name SET DATA TYPE VARCHAR,
+  device_version SET DATA TYPE VARCHAR,
+  layout_engine_name SET DATA TYPE VARCHAR,
+  layout_engine_name_version SET DATA TYPE VARCHAR,
+  layout_engine_name_version_major SET DATA TYPE VARCHAR,
+  layout_engine_version SET DATA TYPE VARCHAR,
+  layout_engine_version_major SET DATA TYPE VARCHAR,
+  operating_system_name SET DATA TYPE VARCHAR,
+  operating_system_name_version SET DATA TYPE VARCHAR,
+  operating_system_version SET DATA TYPE VARCHAR;

--- a/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/users-manifest.sql
+++ b/web/v1/snowflake/sql-runner/sql/standard/99-migrations/1.0.1-migration/users-manifest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS {{.output_schema}}.users_manifest{{.entropy}}
+ ALTER COLUMN domain_userid SET DATA TYPE VARCHAR(128);


### PR DESCRIPTION
Maintenance release to follow up on the Redshift v1.3.0 release's addition of migration files, and add them for the previous releases.

One release (redshift mobile v1.1.0 https://github.com/snowplow/data-models/releases/tag/mobile%2Fredshift%2F1.1.0) specifies a complete teardown is required. I remember at the time that I believe there were major breaking changes, and this release came soon enough after the previous one that it was unlikely for people to have issues.

I don't think it's a good idea to add a playbook to tear everything down under a 'migrations' playbook, so I've left that one to be handled manually should we ever encounter it.