### PR TITLE
Release/web/bigquery/1.0.4

### DIFF
--- a/.test/great_expectations/expectations/web/v1/base.json
+++ b/.test/great_expectations/expectations/web/v1/base.json
@@ -138,7 +138,7 @@
   "meta": {
     "versions": {
       "test_suite_version": "1.1.1",
-      "bigquery_model_version": "1.0.3",
+      "bigquery_model_version": "1.0.4",
       "snowflake_model_version": "1.0.2"
     },
     "great_expectations.__version__": "0.12.0"

--- a/.test/great_expectations/expectations/web/v1/integration_tests.json
+++ b/.test/great_expectations/expectations/web/v1/integration_tests.json
@@ -60,7 +60,7 @@
   "meta": {
     "versions": {
       "test_suite_version": "1.1.1",
-      "bigquery_model_version": "1.0.3"
+      "bigquery_model_version": "1.0.4"
     },
     "__comment__": "expect_column_values_to_be_null on column stray_page_ping has been removed as it is a known issue (https://github.com/snowplow/data-models/issues/92)",
     "great_expectations.__version__": "0.12.0"

--- a/.test/great_expectations/expectations/web/v1/metadata.json
+++ b/.test/great_expectations/expectations/web/v1/metadata.json
@@ -104,7 +104,7 @@
     "versions": {
       "test_suite_version": "1.1.1",
       "redshift_model_version": "1.3.1",
-      "bigquery_model_version": "1.0.3",
+      "bigquery_model_version": "1.0.4",
       "snowflake_model_version": "1.0.2"
     },
     "great_expectations.__version__": "0.12.0"

--- a/.test/great_expectations/expectations/web/v1/page_view_in_session_values.json
+++ b/.test/great_expectations/expectations/web/v1/page_view_in_session_values.json
@@ -28,7 +28,7 @@
     "versions": {
       "test_suite_version": "1.1.1",
       "redshift_model_version": "1.3.1",
-      "bigquery_model_version": "1.0.3",
+      "bigquery_model_version": "1.0.4",
       "snowflake_model_version": "1.0.2"
     },
     "great_expectations.__version__": "0.12.0"

--- a/.test/great_expectations/expectations/web/v1/page_views.json
+++ b/.test/great_expectations/expectations/web/v1/page_views.json
@@ -226,7 +226,7 @@
     "versions": {
       "test_suite_version": "1.1.1",
       "redshift_model_version": "1.3.1",
-      "bigquery_model_version": "1.0.3",
+      "bigquery_model_version": "1.0.4",
       "snowflake_model_version": "1.0.2"
     },
     "great_expectations.__version__": "0.12.0"

--- a/.test/great_expectations/expectations/web/v1/sessions.json
+++ b/.test/great_expectations/expectations/web/v1/sessions.json
@@ -182,7 +182,7 @@
     "versions": {
       "test_suite_version": "1.1.1",
       "redshift_model_version": "1.3.1",
-      "bigquery_model_version": "1.0.3",
+      "bigquery_model_version": "1.0.4",
       "snowflake_model_version": "1.0.2"
     },
     "great_expectations.__version__": "0.12.0"

--- a/.test/great_expectations/expectations/web/v1/users.json
+++ b/.test/great_expectations/expectations/web/v1/users.json
@@ -118,7 +118,7 @@
     "versions": {
       "test_suite_version": "1.1.1",
       "redshift_model_version": "1.3.1",
-      "bigquery_model_version": "1.0.3",
+      "bigquery_model_version": "1.0.4",
       "snowflake_model_version": "1.0.2"
     },
     "great_expectations.__version__": "0.12.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+BigQuery Web Version 1.0.4 (2022-12-13)
+----------------------------------------
+Snowflake Web: Fix upsert limit in commit_table procedure (Close #75)
+
 Snowflake Web Version 1.0.2 (2022-10-13)
 ----------------------------------------
 Snowflake Web: Optimise partition pruning (Close #140)

--- a/web/v1/bigquery/CHANGELOG
+++ b/web/v1/bigquery/CHANGELOG
@@ -1,3 +1,7 @@
+Version 1.0.4 (2022-12-13)
+--------------------------
+BigQuery: Fix upsert limit in commit_table procedure (Close #75)
+
 Version 1.0.3 (2021-03-24)
 --------------------------
 BigQuery: Change session lookback to use days rather than hours (#60)

--- a/web/v1/bigquery/sql-runner/playbooks/standard/00-setup/00-setup-metadata.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/00-setup/00-setup-metadata.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/00-setup/99-metadata-complete.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/00-setup/99-metadata-complete.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/00-setup/XX-destroy-metadata.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/00-setup/XX-destroy-metadata.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/01-base/01-base-main.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/01-base/01-base-main.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:           bigquery/web/1.0.3
+  :model_version:           bigquery/web/1.0.4
   :input_schema:            atomic
   :scratch_schema:          scratch
   :output_schema:           derived

--- a/web/v1/bigquery/sql-runner/playbooks/standard/01-base/99-base-complete.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/01-base/99-base-complete.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/01-base/XX-destroy-base.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/01-base/XX-destroy-base.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/02-page-views/01-page-views-main.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/02-page-views/01-page-views-main.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:         bigquery/web/1.0.3
+  :model_version:         bigquery/web/1.0.4
   :scratch_schema:        scratch
   :output_schema:         derived
   :entropy:               ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/02-page-views/99-page-views-complete.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/02-page-views/99-page-views-complete.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/02-page-views/XX-destroy-page-views.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/02-page-views/XX-destroy-page-views.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/03-sessions/01-sessions-main.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/03-sessions/01-sessions-main.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:         bigquery/web/1.0.3
+  :model_version:         bigquery/web/1.0.4
   :scratch_schema:        scratch
   :output_schema:         derived
   :entropy:               ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/03-sessions/99-sessions-complete.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/03-sessions/99-sessions-complete.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/03-sessions/XX-destroy-sessions.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/03-sessions/XX-destroy-sessions.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/04-users/01-users-main.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/04-users/01-users-main.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:         bigquery/web/1.0.3
+  :model_version:         bigquery/web/1.0.4
   :scratch_schema:        scratch
   :output_schema:         derived
   :start_date:            2020-01-01

--- a/web/v1/bigquery/sql-runner/playbooks/standard/04-users/99-users-complete.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/04-users/99-users-complete.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/playbooks/standard/04-users/XX-destroy-users.yml.tmpl
+++ b/web/v1/bigquery/sql-runner/playbooks/standard/04-users/XX-destroy-users.yml.tmpl
@@ -4,7 +4,7 @@
   :project:
   :region:
 :variables:
-  :model_version:      bigquery/web/1.0.3
+  :model_version:      bigquery/web/1.0.4
   :scratch_schema:     scratch
   :output_schema:      derived
   :entropy:            ""

--- a/web/v1/bigquery/sql-runner/sql/standard/00-setup/01-main/01-functions-and-procedures.sql
+++ b/web/v1/bigquery/sql-runner/sql/standard/00-setup/01-main/01-functions-and-procedures.sql
@@ -105,7 +105,7 @@ BEGIN
 
   -- Get lower limit
   EXECUTE IMMEDIATE
-    format("SELECT TIMESTAMP_SUB(MIN(%s), INTERVAL {{or .upsert_lookback_days 30}} DAY) FROM %s", partitionKey, TARGET_PATH) INTO LOWER_LIMIT;
+    format("SELECT TIMESTAMP_SUB(MIN(%s), INTERVAL {{or .upsert_lookback_days 30}} DAY) FROM %s", partitionKey, SOURCE_PATH) INTO LOWER_LIMIT;
 
   -- Perform DELETE <> INSERT transaction
   BEGIN


### PR DESCRIPTION
Patch release for: BigQuery Web: Fix upsert limit in commit_table procedure (Close #75)

This is to make sure the **upsert_lookback_days** variable works as it was intended to.

```
upsert_lookback_days:  default 30. Period of time (in days) to look back over the production table in order to find rows to delete when upserting data. Where performance is not a concern, should be set to as long a value as possible.
```
PR check with Great Expectations ran fine.